### PR TITLE
Phase 2: Remove remaining operator user references from setup modules

### DIFF
--- a/scripts/server/setup-bash-configuration.sh
+++ b/scripts/server/setup-bash-configuration.sh
@@ -2,7 +2,7 @@
 #
 # setup-bash-configuration.sh - Bash configuration setup module
 #
-# This script installs comprehensive bash configuration for both administrator and operator users.
+# This script installs comprehensive bash configuration for the administrator user.
 # It sets up per-user configuration directories, symlinks, and profile redirectors for
 # consistent bash environment across both accounts.
 #
@@ -147,7 +147,7 @@ check_success() {
 #
 
 # Install Bash Configuration
-set_section "Installing Bash Configuration for Administrator and Operator"
+set_section "Installing Bash Configuration for Administrator"
 
 # Check if bash configuration is available in setup package
 BASH_CONFIG_SOURCE="${SETUP_DIR}/bash"
@@ -240,13 +240,6 @@ if [[ -d "${BASH_CONFIG_SOURCE}" ]]; then
 
   # Install for Administrator
   install_bash_config_for_user "${ADMIN_USERNAME}" "/Users/${ADMIN_USERNAME}"
-
-  # Install for Operator (if configured and account exists)
-  if [[ -n "${OPERATOR_USERNAME:-}" ]] && dscl . -list /Users 2>/dev/null | grep -q "^${OPERATOR_USERNAME}$"; then
-    install_bash_config_for_user "${OPERATOR_USERNAME}" "/Users/${OPERATOR_USERNAME}"
-  else
-    log "Operator account not configured or not found - skipping bash config installation for operator"
-  fi
 
   check_success "Bash configuration installation"
 else

--- a/scripts/server/setup-log-rotation.sh
+++ b/scripts/server/setup-log-rotation.sh
@@ -162,7 +162,7 @@ configure_log_rotation() {
     # Copy our logrotate configuration
     sudo -p "[Logrotate setup] Enter password to install logrotate config: " cp "${CONFIG_FILE%/*}/logrotate.conf" "${LOGROTATE_CONFIG_DIR}/"
 
-    # Make config user-writable so both admin and operator can modify it (664)
+    # Make config user-writable so admin user can modify it (664)
     sudo -p "[Logrotate setup] Enter password to set config permissions: " chmod 664 "${LOGROTATE_CONFIG_DIR}/logrotate.conf"
     sudo -p "[Logrotate setup] Enter password to set config ownership: " chown "${ADMIN_USERNAME}:admin" "${LOGROTATE_CONFIG_DIR}/logrotate.conf"
     check_success "Logrotate configuration install"

--- a/scripts/server/setup-package-installation.sh
+++ b/scripts/server/setup-package-installation.sh
@@ -269,8 +269,6 @@ if [[ "${SKIP_PACKAGES}" = false ]]; then
     # Get estimated size for large packages
     local size_hint=""
     case "${cask}" in
-      plex-media-server) size_hint=" (~250 MB)" ;;
-      filebot) size_hint=" (~50 MB)" ;;
       vlc) size_hint=" (~75 MB)" ;;
       bbedit) size_hint=" (~25 MB)" ;;
       *) size_hint="" ;;

--- a/scripts/server/setup-shell-configuration.sh
+++ b/scripts/server/setup-shell-configuration.sh
@@ -2,8 +2,8 @@
 #
 # setup-shell-configuration.sh - Shell configuration module
 #
-# This script changes the default shell to Homebrew bash for both admin and
-# operator users. It adds Homebrew bash to /etc/shells, updates user shells,
+# This script changes the default shell to Homebrew bash for the admin
+# user. It adds Homebrew bash to /etc/shells, updates the user shell,
 # and sets up profile compatibility for bash by copying .zprofile to .profile.
 #
 # Usage: ./setup-shell-configuration.sh [--force]
@@ -51,9 +51,6 @@ fi
 ADMIN_USERNAME=$(whoami)
 HOSTNAME="${HOSTNAME_OVERRIDE:-${SERVER_NAME}}"
 HOSTNAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<<"${HOSTNAME}")"
-# Set fallback for OPERATOR_USERNAME if not defined in config
-OPERATOR_USERNAME="${OPERATOR_USERNAME:-operator}"
-
 # Set up logging
 LOG_DIR="${HOME}/.local/state"
 LOG_FILE="${LOG_DIR}/${HOSTNAME_LOWER}-setup.log"
@@ -165,24 +162,11 @@ configure_shell() {
     sudo -p "[Shell setup] Enter password to change admin shell: " chsh -s "${HOMEBREW_BASH}" "${ADMIN_USERNAME}"
     check_success "Admin user shell change"
 
-    # Change shell for operator user if it exists
-    if dscl . -list /Users 2>/dev/null | grep -q "^${OPERATOR_USERNAME}$"; then
-      log "Setting shell to Homebrew bash for operator user"
-      sudo -p "[Shell setup] Enter password to change operator shell: " chsh -s "${HOMEBREW_BASH}" "${OPERATOR_USERNAME}"
-      check_success "Operator user shell change"
-    fi
-
     # Copy .zprofile to .profile for bash compatibility
     log "Setting up bash profile compatibility"
     if [[ -f "/Users/${ADMIN_USERNAME}/.zprofile" ]]; then
       log "Copying admin .zprofile to .profile for bash compatibility"
       cp "/Users/${ADMIN_USERNAME}/.zprofile" "/Users/${ADMIN_USERNAME}/.profile"
-    fi
-
-    if dscl . -list /Users 2>/dev/null | grep -q "^${OPERATOR_USERNAME}$"; then
-      log "Copying operator .zprofile to .profile for bash compatibility"
-      sudo -p "[Shell setup] Enter password to copy operator profile: " cp "/Users/${OPERATOR_USERNAME}/.zprofile" "/Users/${OPERATOR_USERNAME}/.profile" 2>/dev/null || true
-      sudo chown "${OPERATOR_USERNAME}:staff" "/Users/${OPERATOR_USERNAME}/.profile" 2>/dev/null || true
     fi
 
     check_success "Bash profile compatibility setup"

--- a/scripts/server/setup-ssh-access.sh
+++ b/scripts/server/setup-ssh-access.sh
@@ -4,7 +4,7 @@
 #
 # This script configures SSH access including service enablement and key setup.
 # It handles Full Disk Access requirements for SSH enablement and copies
-# SSH keys for both admin and operator accounts.
+# SSH keys for the admin account.
 #
 # Usage: ./setup-ssh-access.sh [--force]
 #   --force: Skip all confirmation prompts
@@ -222,28 +222,6 @@ if [[ -d "${SSH_KEY_SOURCE}" ]]; then
     check_success "Admin SSH private key setup"
   fi
 
-  # Set up operator SSH keys if available and operator account exists
-  if [[ -f "${SSH_KEY_SOURCE}/operator_authorized_keys" ]] && [[ -n "${OPERATOR_USERNAME:-}" ]]; then
-    if dscl . -list /Users 2>/dev/null | grep -q "^${OPERATOR_USERNAME}$"; then
-      OPERATOR_SSH_DIR="/Users/${OPERATOR_USERNAME}/.ssh"
-      log "Setting up SSH keys for operator account"
-
-      sudo -p "[SSH setup] Enter password to configure operator SSH keys: " mkdir -p "${OPERATOR_SSH_DIR}"
-      sudo cp "${SSH_KEY_SOURCE}/operator_authorized_keys" "${OPERATOR_SSH_DIR}/authorized_keys"
-      sudo chmod 700 "${OPERATOR_SSH_DIR}"
-      sudo chmod 600 "${OPERATOR_SSH_DIR}/authorized_keys"
-      sudo chown -R "${OPERATOR_USERNAME}" "${OPERATOR_SSH_DIR}"
-
-      check_success "Operator SSH key setup"
-
-      # Add operator to SSH access group
-      log "Adding operator to SSH access group"
-      sudo -p "[SSH setup] Enter password to add operator to SSH access group: " dseditgroup -o edit -a "${OPERATOR_USERNAME}" -t user com.apple.access_ssh
-      check_success "Operator SSH group membership"
-    else
-      log "Operator account not found - skipping operator SSH key setup"
-    fi
-  fi
 else
   log "No SSH keys found at ${SSH_KEY_SOURCE} - manual key setup will be required"
 fi

--- a/scripts/server/setup-system-preferences.sh
+++ b/scripts/server/setup-system-preferences.sh
@@ -150,9 +150,6 @@ check_success() {
   fi
 }
 
-# Set up required variables with fallbacks
-OPERATOR_USERNAME="${OPERATOR_USERNAME:-operator}"
-
 # Fast User Switching
 section "Enabling Fast User Switching"
 log "Configuring Fast User Switching for multi-user access"
@@ -160,24 +157,19 @@ sudo -p "[System setup] Enter password to enable multiple user sessions: " defau
 check_success "Fast User Switching configuration"
 
 # Fast User Switching menu bar style and visibility
-defaults write .GlobalPreferences userMenuExtraStyle -int 1                                                                                                     # username
-sudo -p "[User setup] Enter password to configure operator menu style: " -iu "${OPERATOR_USERNAME}" defaults write .GlobalPreferences userMenuExtraStyle -int 1 # username
-defaults -currentHost write com.apple.controlcenter UserSwitcher -int 2                                                                                         # menubar
-sudo -iu "${OPERATOR_USERNAME}" defaults -currentHost write com.apple.controlcenter UserSwitcher -int 2                                                         # menubar
+defaults write .GlobalPreferences userMenuExtraStyle -int 1             # username
+defaults -currentHost write com.apple.controlcenter UserSwitcher -int 2 # menubar
 
 # Fix scroll setting
 section "Fix scroll setting"
 log "Fixing Apple's default scroll setting"
 defaults write -g com.apple.swipescrolldirection -bool false
-sudo -p "[User setup] Enter password to configure operator scroll direction: " -iu "${OPERATOR_USERNAME}" defaults write -g com.apple.swipescrolldirection -bool false
 check_success "Fix scroll setting"
 
 # Configure screen saver password requirement
 section "Configuring screen saver password requirement"
 defaults -currentHost write com.apple.screensaver askForPassword -int 1
 defaults -currentHost write com.apple.screensaver askForPasswordDelay -int 0
-sudo -p "[Security setup] Enter password to configure operator screen saver security: " -u "${OPERATOR_USERNAME}" defaults -currentHost write com.apple.screensaver askForPassword -int 1
-sudo -iu "${OPERATOR_USERNAME}" defaults -currentHost write com.apple.screensaver askForPasswordDelay -int 0
 log "Enabled immediate password requirement after screen saver"
 
 # Run software updates if not skipped

--- a/scripts/server/setup-terminal-profiles.sh
+++ b/scripts/server/setup-terminal-profiles.sh
@@ -4,7 +4,7 @@
 #
 # This script configures terminal applications with custom profiles for better
 # accessibility and visibility. Imports user-specified profiles and sets them
-# as defaults for both admin and operator users to ensure consistent terminal
+# as defaults for the admin user to ensure consistent terminal
 # appearance across all sessions.
 #
 # Usage: ./setup-terminal-profiles.sh [--force]
@@ -46,9 +46,6 @@ fi
 ADMIN_USERNAME=$(whoami)
 HOSTNAME="${HOSTNAME_OVERRIDE:-${SERVER_NAME}}"
 HOSTNAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<<"${HOSTNAME}")"
-# Set fallback for OPERATOR_USERNAME if not defined in config
-OPERATOR_USERNAME="${OPERATOR_USERNAME:-operator}"
-
 # Set up logging
 LOG_DIR="${HOME}/.local/state"
 LOG_FILE="${LOG_DIR}/${HOSTNAME_LOWER}-setup.log"
@@ -195,13 +192,12 @@ import_terminal_profile_for_user() {
 
   log "Configuring Terminal profile '${profile_name}' for user: ${username}"
 
-  if [[ "${username}" == "${ADMIN_USERNAME}" ]]; then
-    # Import for current admin user - direct registration
-    log "Opening Terminal profile to import settings..."
+  # Import for current admin user - direct registration
+  log "Opening Terminal profile to import settings..."
 
-    # Use AppleScript to safely manage windows without closing the calling script's window
-    local applescript_result
-    applescript_result=$(osascript -e "
+  # Use AppleScript to safely manage windows without closing the calling script's window
+  local applescript_result
+  applescript_result=$(osascript -e "
 tell application \"Terminal\"
     -- Save reference to current window (the one running the script)
     set current_window to front window
@@ -234,57 +230,32 @@ tell application \"Terminal\"
 end tell
 ")
 
-    if [[ "${applescript_result}" == "success" ]]; then
-      log "Successfully imported Terminal profile and restored calling window focus"
+  if [[ "${applescript_result}" == "success" ]]; then
+    log "Successfully imported Terminal profile and restored calling window focus"
 
-      # Set as default and startup profile
-      defaults write com.apple.Terminal "Default Window Settings" -string "${profile_name}"
-      defaults write com.apple.Terminal "Startup Window Settings" -string "${profile_name}"
+    # Set as default and startup profile
+    defaults write com.apple.Terminal "Default Window Settings" -string "${profile_name}"
+    defaults write com.apple.Terminal "Startup Window Settings" -string "${profile_name}"
 
-      local new_default
-      new_default=$(defaults read com.apple.Terminal "Default Window Settings")
-      if [[ ${new_default} != "${profile_name}" ]]; then
-        collect_error "Failed to set ${profile_name} as Default profile for ${username}"
-      fi
-
-      local new_startup
-      new_startup=$(defaults read com.apple.Terminal "Startup Window Settings")
-      if [[ ${new_startup} != "${profile_name}" ]]; then
-        collect_error "Failed to set ${profile_name} as Startup profile for ${username}"
-      fi
-
-      log "Successfully imported Terminal profile for ${username}"
-      log "New profile will be active in next Terminal session"
-      return 0
-    else
-      log "AppleScript window management failed: ${applescript_result}"
-      collect_error "Failed to import Terminal profile for ${username} - window management issue"
-      return 1
+    local new_default
+    new_default=$(defaults read com.apple.Terminal "Default Window Settings")
+    if [[ ${new_default} != "${profile_name}" ]]; then
+      collect_error "Failed to set ${profile_name} as Default profile for ${username}"
     fi
+
+    local new_startup
+    new_startup=$(defaults read com.apple.Terminal "Startup Window Settings")
+    if [[ ${new_startup} != "${profile_name}" ]]; then
+      collect_error "Failed to set ${profile_name} as Startup profile for ${username}"
+    fi
+
+    log "Successfully imported Terminal profile for ${username}"
+    log "New profile will be active in next Terminal session"
+    return 0
   else
-    # For operator user - copy profile file to their config directory
-    # Registration will happen during operator-first-login.sh
-    local operator_home="/Users/${username}"
-    local operator_config_dir="${operator_home}/.config/terminal"
-    local operator_profile_file
-    operator_profile_file="${operator_config_dir}/$(basename "${profile_file}")"
-
-    # Create config directory with proper ownership
-    if ! sudo -iu "${username}" mkdir -p "${operator_config_dir}"; then
-      collect_error "Failed to create Terminal config directory for ${username}"
-      return 1
-    fi
-
-    # Copy profile file to operator's config directory
-    if sudo cp "${profile_file}" "${operator_profile_file}" \
-      && sudo chown "${username}:staff" "${operator_profile_file}"; then
-      log "Successfully copied Terminal profile to ${operator_profile_file}"
-      log "Profile will be registered during operator first login"
-      return 0
-    else
-      collect_error "Failed to copy Terminal profile file for ${username}"
-      return 1
-    fi
+    log "AppleScript window management failed: ${applescript_result}"
+    collect_error "Failed to import Terminal profile for ${username} - window management issue"
+    return 1
   fi
 }
 
@@ -306,48 +277,19 @@ import_iterm2_preferences_for_user() {
     return 0
   fi
 
-  if [[ "${username}" == "${ADMIN_USERNAME}" ]]; then
-    # Import for current admin user - file copy
-    if cp -f "${preferences_file}" "${HOME}/Library/Preferences"; then
-      killall iTerm2 &>/dev/null || true
-      sleep 1
-      open -a iTerm2 &>/dev/null || true
-      sleep 1
-      killall iTerm2 &>/dev/null || true
-      log "Successfully imported iTerm2 preferences for ${username}"
-      log "Restart iTerm2 to see changes"
-      return 0
-    else
-      collect_error "Failed to import iTerm2 preferences for ${username}"
-      return 1
-    fi
+  # Import for current admin user - file copy
+  if cp -f "${preferences_file}" "${HOME}/Library/Preferences"; then
+    killall iTerm2 &>/dev/null || true
+    sleep 1
+    open -a iTerm2 &>/dev/null || true
+    sleep 1
+    killall iTerm2 &>/dev/null || true
+    log "Successfully imported iTerm2 preferences for ${username}"
+    log "Restart iTerm2 to see changes"
+    return 0
   else
-    # For operator user - copy preferences file to their config directory
-    # Import will happen during operator-first-login.sh
-    local operator_home="/Users/${username}"
-    local operator_library_prefs_dir="${operator_home}/Library/Preferences"
-
-    # Create config directory with proper ownership
-    if ! sudo -iu "${username}" mkdir -p "${operator_library_prefs_dir}"; then
-      collect_error "Failed to create iTerm2 config directory for ${username}"
-      return 1
-    fi
-
-    # Copy preferences file to operator's config directory
-    if sudo cp "${preferences_file}" "${operator_library_prefs_dir}" \
-      && sudo chown "${username}:staff" "${operator_library_prefs_dir}/${preferences_file}"; then
-      sudo -iu "{username}" killall iTerm2 &>/dev/null || true
-      sleep 1
-      sudo -iu "{username}" open -a iTerm2 &>/dev/null || true
-      sleep 1
-      sudo -iu "{username}" killall iTerm2 &>/dev/null || true
-      log "Successfully copied iTerm2 preferences to ${operator_library_prefs_dir}"
-      log "Preferences will be imported during operator first login"
-      return 0
-    else
-      collect_error "Failed to copy iTerm2 preferences file for ${username}"
-      return 1
-    fi
+    collect_error "Failed to import iTerm2 preferences for ${username}"
+    return 1
   fi
 }
 
@@ -391,26 +333,15 @@ configure_terminal_profiles() {
   # Check if terminal apps are running
   check_running_terminal_apps
 
-  # Create backups for both users
+  # Create backups
   log "Creating preference backups..."
   backup_user_preferences "${ADMIN_USERNAME}"
-
-  if dscl . -list /Users 2>/dev/null | grep -q "^${OPERATOR_USERNAME}$"; then
-    backup_user_preferences "${OPERATOR_USERNAME}"
-  else
-    log "Operator user not found - will configure when account is created"
-  fi
 
   # Import Terminal profiles
   if [[ -n "${TERMINAL_PROFILE_PATH}" ]] && [[ -f "${TERMINAL_PROFILE_PATH}" ]]; then
     log "Importing Terminal profiles..."
     import_terminal_profile_for_user "${ADMIN_USERNAME}" "${TERMINAL_PROFILE_PATH}"
     check_optional_success $? "Terminal profile import for admin user"
-
-    if dscl . -list /Users 2>/dev/null | grep -q "^${OPERATOR_USERNAME}$"; then
-      import_terminal_profile_for_user "${OPERATOR_USERNAME}" "${TERMINAL_PROFILE_PATH}"
-      check_optional_success $? "Terminal profile import for operator user"
-    fi
   elif [[ -n "${TERMINAL_PROFILE_PATH}" ]]; then
     log "⚠️  Terminal profile file not found: ${TERMINAL_PROFILE_PATH} (optional feature - continuing)"
   else
@@ -422,11 +353,6 @@ configure_terminal_profiles() {
     log "Importing iTerm2 preferences..."
     import_iterm2_preferences_for_user "${ADMIN_USERNAME}" "${ITERM2_PREFERENCES_PATH}"
     check_optional_success $? "iTerm2 preferences import for admin user"
-
-    if dscl . -list /Users 2>/dev/null | grep -q "^${OPERATOR_USERNAME}$"; then
-      import_iterm2_preferences_for_user "${OPERATOR_USERNAME}" "${ITERM2_PREFERENCES_PATH}"
-      check_optional_success $? "iTerm2 preferences import for operator user"
-    fi
   elif [[ "${USE_ITERM2:-false}" == "true" ]] && [[ ! -f "${ITERM2_PREFERENCES_PATH}" ]]; then
     log "⚠️  iTerm2 preferences file not found: ${ITERM2_PREFERENCES_PATH} (optional feature - continuing)"
   else

--- a/scripts/server/setup-timemachine.sh
+++ b/scripts/server/setup-timemachine.sh
@@ -4,7 +4,7 @@
 #
 # This script configures Time Machine backup with SMB destinations using credentials
 # stored in the keychain. It handles URL configuration, credential retrieval,
-# destination setup, and menu bar integration for both admin and operator users.
+# destination setup, and menu bar integration for the admin user.
 #
 # Usage: ./setup-timemachine.sh [--force]
 #   --force: Skip all confirmation prompts
@@ -220,10 +220,6 @@ if [[ -f "${TIMEMACHINE_CONFIG_FILE}" ]]; then
             defaults write com.apple.systemuiserver menuExtras -array-add "/System/Library/CoreServices/Menu Extras/TimeMachine.menu"
             NEED_SYSTEMUI_RESTART=true
             check_success "Time Machine menu bar addition"
-            if [[ -n "${OPERATOR_USERNAME:-}" ]] && dscl . -list /Users 2>/dev/null | grep -q "^${OPERATOR_USERNAME}$"; then
-              sudo -iu "${OPERATOR_USERNAME}" defaults write com.apple.systemuiserver menuExtras -array-add "/System/Library/CoreServices/Menu Extras/TimeMachine.menu"
-              check_success "Time Machine menu bar addition for operator"
-            fi
           else
             log "Configuring Time Machine destination: ${TM_URL}"
             # Construct the full SMB URL with credentials
@@ -242,10 +238,6 @@ if [[ -f "${TIMEMACHINE_CONFIG_FILE}" ]]; then
                 defaults write com.apple.systemuiserver menuExtras -array-add "/System/Library/CoreServices/Menu Extras/TimeMachine.menu"
                 NEED_SYSTEMUI_RESTART=true
                 check_success "Time Machine menu bar addition"
-                if [[ -n "${OPERATOR_USERNAME:-}" ]] && dscl . -list /Users 2>/dev/null | grep -q "^${OPERATOR_USERNAME}$"; then
-                  sudo -iu "${OPERATOR_USERNAME}" defaults write com.apple.systemuiserver menuExtras -array-add "/System/Library/CoreServices/Menu Extras/TimeMachine.menu"
-                  check_success "Time Machine menu bar addition for operator"
-                fi
               else
                 collect_error "Failed to enable Time Machine"
               fi


### PR DESCRIPTION
## Summary

- Remove dead operator user logic from 7 setup modules retained during Phase 1
- **Critical fix**: `setup-system-preferences.sh` ran `sudo -iu operator` without existence checks — would actively error on a single-user system
- Other modules had operator code guarded by `dscl` existence checks (harmless but dead)
- Remove stale `plex-media-server` and `filebot` size hints from package installation

## Verification

- `shellcheck` clean on all 8 modified scripts
- `shfmt -d -i 2 -ci -bn` clean on all 8 modified scripts
- `grep -r "operator\|OPERATOR" --include="*.sh"` returns zero hits
- `grep -r "plex\|filebot" --include="*.sh"` returns zero real hits (only substring match in "complexities")

## Files changed (8)

| File | Change |
|------|--------|
| `setup-system-preferences.sh` | Removed unguarded `sudo -iu operator` calls (CRITICAL) |
| `setup-shell-configuration.sh` | Removed operator shell change and profile copy |
| `setup-terminal-profiles.sh` | Removed operator branches from import functions |
| `setup-ssh-access.sh` | Removed operator SSH key deployment block |
| `setup-bash-configuration.sh` | Removed operator bash config installation |
| `setup-timemachine.sh` | Removed operator menu bar additions |
| `setup-log-rotation.sh` | Updated comment to reflect single-user |
| `setup-package-installation.sh` | Removed plex/filebot size hints |

## Test plan

- [ ] Verify `shellcheck` passes on all modified scripts
- [ ] Verify `shfmt` formatting is clean
- [ ] Verify zero `operator`/`OPERATOR` grep hits in `*.sh`
- [ ] Verify zero `plex`/`filebot` grep hits in `*.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)