### PR TITLE
feat(app-setup): add dev tool setup scripts (Phase 3)

### DIFF
--- a/app-setup/android-setup.sh
+++ b/app-setup/android-setup.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+#
+# android-setup.sh - Android SDK configuration
+#
+# This script configures the Android SDK environment including license
+# acceptance, SDK component installation, and shell environment setup.
+# Android command line tools are installed via Homebrew (casks.txt).
+#
+# Prerequisites:
+# - android-commandlinetools installed via Homebrew
+# - Java (temurin) installed via Homebrew
+#
+# Usage: ./android-setup.sh [--force]
+#   --force: Skip confirmation prompts
+#
+# Author: Andrew Rich <andrew.rich@gmail.com>
+# Created: 2026-02-17
+
+set -euo pipefail
+
+# Parse command line arguments
+FORCE=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --force)
+      FORCE=true
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [--force]"
+      exit 1
+      ;;
+  esac
+done
+
+# Configuration loading
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/../config/config.conf"
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  CONFIG_FILE="${SCRIPT_DIR}/config/config.conf"
+fi
+
+if [[ -f "${CONFIG_FILE}" ]]; then
+  # shellcheck source=/dev/null
+  source "${CONFIG_FILE}"
+else
+  echo "Error: Configuration file not found"
+  echo "Checked: ${SCRIPT_DIR}/../config/config.conf"
+  echo "Checked: ${SCRIPT_DIR}/config/config.conf"
+  exit 1
+fi
+
+# Derived variables
+HOSTNAME="${HOSTNAME_OVERRIDE:-${SERVER_NAME}}"
+HOSTNAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<<"${HOSTNAME}")"
+
+# SDK version from config with default
+SDK_VERSION="${ANDROID_SDK_VERSION:-34}"
+
+# Logging configuration
+LOG_DIR="${HOME}/.local/state"
+LOG_FILE="${LOG_DIR}/${HOSTNAME_LOWER}-app-setup.log"
+mkdir -p "${LOG_DIR}"
+
+# Logging functions
+log() {
+  local timestamp
+  timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+  echo "[${timestamp}] $*" >>"${LOG_FILE}"
+}
+
+show_log() {
+  echo "$*"
+  log "$*"
+}
+
+section() {
+  log "====== $* ======"
+}
+
+# Error collection
+COLLECTED_ERRORS=()
+CURRENT_SECTION="Android SDK Setup"
+
+collect_error() {
+  local message="$1"
+  show_log "ERROR: ${message}"
+  COLLECTED_ERRORS+=("[${CURRENT_SECTION}] ${message}")
+}
+
+check_success() {
+  local exit_code=$1
+  local operation="$2"
+
+  if [[ ${exit_code} -eq 0 ]]; then
+    show_log "OK: ${operation}"
+    return 0
+  else
+    collect_error "${operation} failed with exit code ${exit_code}"
+    return 1
+  fi
+}
+
+# Determine ANDROID_HOME from Homebrew cask location
+determine_android_home() {
+  # Homebrew installs android-commandlinetools to this location
+  local homebrew_prefix
+  homebrew_prefix="$(brew --prefix 2>/dev/null || echo "/opt/homebrew")"
+  local android_home="${homebrew_prefix}/share/android-commandlinetools"
+
+  if [[ -d "${android_home}" ]]; then
+    echo "${android_home}"
+    return 0
+  fi
+
+  # Fallback: check standard locations
+  if [[ -d "${HOME}/Library/Android/sdk" ]]; then
+    echo "${HOME}/Library/Android/sdk"
+    return 0
+  fi
+
+  # Return the Homebrew path even if it doesn't exist yet
+  echo "${android_home}"
+  return 1
+}
+
+# Main execution
+main() {
+  section "Android SDK Configuration"
+  show_log "Starting Android SDK setup..."
+  show_log "Target SDK version: ${SDK_VERSION}"
+
+  # Verify Java is available
+  section "Verifying Java Installation"
+  if ! command -v java &>/dev/null; then
+    collect_error "Java not found - install temurin via Homebrew first (check formulae.txt)"
+    exit 1
+  fi
+
+  local java_version
+  java_version="$(java -version 2>&1 | head -n 1)"
+  show_log "Java: ${java_version}"
+
+  # Determine ANDROID_HOME
+  section "Configuring ANDROID_HOME"
+  local android_home
+  android_home="$(determine_android_home)" || true
+
+  if [[ ! -d "${android_home}" ]]; then
+    collect_error "Android command line tools directory not found: ${android_home}"
+    show_log "Install android-commandlinetools via Homebrew first (check casks.txt)"
+    exit 1
+  fi
+
+  show_log "ANDROID_HOME: ${android_home}"
+  export ANDROID_HOME="${android_home}"
+
+  # Set up environment variables in shell profiles
+  section "Configuring Shell Environment"
+
+  local env_block
+  env_block=$(
+    cat <<'ENVEOF'
+
+# Android SDK
+export ANDROID_HOME="ANDROID_HOME_PLACEHOLDER"
+export PATH="${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/emulator:${PATH}"
+ENVEOF
+  )
+  env_block="${env_block//ANDROID_HOME_PLACEHOLDER/${android_home}}"
+
+  for profile in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.bash_profile" "${HOME}/.profile"; do
+    if [[ -f "${profile}" ]]; then
+      if ! grep -q "ANDROID_HOME" "${profile}"; then
+        show_log "Adding ANDROID_HOME to ${profile}"
+        echo "${env_block}" >>"${profile}"
+        log "Updated ${profile} with ANDROID_HOME"
+      else
+        log "ANDROID_HOME already in ${profile}"
+      fi
+    fi
+  done
+
+  # Add to current session
+  export PATH="${android_home}/platform-tools:${android_home}/emulator:${PATH}"
+
+  # Find sdkmanager
+  local sdkmanager=""
+  if command -v sdkmanager &>/dev/null; then
+    sdkmanager="sdkmanager"
+  elif [[ -x "${android_home}/cmdline-tools/latest/bin/sdkmanager" ]]; then
+    sdkmanager="${android_home}/cmdline-tools/latest/bin/sdkmanager"
+  elif [[ -x "${android_home}/bin/sdkmanager" ]]; then
+    sdkmanager="${android_home}/bin/sdkmanager"
+  else
+    collect_error "sdkmanager not found in PATH or Android SDK directory"
+    exit 1
+  fi
+
+  show_log "Using sdkmanager: ${sdkmanager}"
+
+  # Accept SDK licenses
+  section "Accepting Android SDK Licenses"
+  show_log "Accepting all Android SDK licenses..."
+
+  local license_exit=0
+  yes | "${sdkmanager}" --licenses &>/dev/null || license_exit=$?
+
+  # sdkmanager --licenses can exit non-zero even when all licenses are accepted
+  if [[ ${license_exit} -ne 0 ]]; then
+    log "sdkmanager --licenses exited with ${license_exit} (may be non-fatal)"
+  fi
+  show_log "OK: SDK license acceptance"
+
+  # Install SDK components
+  section "Installing Android SDK Components"
+
+  local -a sdk_packages=(
+    "platform-tools"
+    "platforms;android-${SDK_VERSION}"
+    "build-tools;${SDK_VERSION}.0.0"
+    "emulator"
+  )
+
+  if [[ "${FORCE}" != true ]]; then
+    show_log ""
+    show_log "The following SDK components will be installed:"
+    for pkg in "${sdk_packages[@]}"; do
+      show_log "  - ${pkg}"
+    done
+    show_log ""
+
+    read -r -n 1 -p "Proceed with SDK component installation? (Y/n): " response
+    echo
+    case "${response}" in
+      [nN])
+        show_log "SDK component installation cancelled by user"
+        exit 0
+        ;;
+      *)
+        show_log "Proceeding with SDK component installation..."
+        ;;
+    esac
+  fi
+
+  local install_exit pkg_dir
+  for pkg in "${sdk_packages[@]}"; do
+    # Check if already installed by looking for the package directory
+    # Convert package name to directory path (e.g., "platforms;android-34" -> "platforms/android-34")
+    pkg_dir="${pkg//;/\/}"
+    if [[ -d "${android_home}/${pkg_dir}" ]]; then
+      show_log "Already installed: ${pkg}"
+      continue
+    fi
+
+    show_log "Installing: ${pkg}..."
+    install_exit=0
+    yes | "${sdkmanager}" "${pkg}" >>"${LOG_FILE}" 2>&1 || install_exit=$?
+    check_success "${install_exit}" "SDK component: ${pkg}" || true
+  done
+
+  # Verification
+  section "Verifying Android SDK Setup"
+  show_log "ANDROID_HOME: ${ANDROID_HOME}"
+
+  if command -v adb &>/dev/null || [[ -x "${android_home}/platform-tools/adb" ]]; then
+    local adb_cmd="adb"
+    if ! command -v adb &>/dev/null; then
+      adb_cmd="${android_home}/platform-tools/adb"
+    fi
+    local adb_version
+    adb_version="$("${adb_cmd}" --version 2>/dev/null | head -n 1 || echo "unknown")"
+    show_log "adb: ${adb_version}"
+  else
+    collect_error "adb not found after SDK installation"
+  fi
+
+  show_log ""
+  show_log "Installed SDK packages:"
+  "${sdkmanager}" --list 2>/dev/null | tee -a "${LOG_FILE}" || true
+
+  if [[ ${#COLLECTED_ERRORS[@]} -gt 0 ]]; then
+    show_log ""
+    show_log "Android SDK setup completed with ${#COLLECTED_ERRORS[@]} error(s)"
+    exit 1
+  fi
+
+  show_log "Android SDK setup completed successfully"
+}
+
+main "$@"

--- a/app-setup/dotfiles-setup.sh
+++ b/app-setup/dotfiles-setup.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+#
+# dotfiles-setup.sh - Dotfiles clone and installation
+#
+# This script clones the user's dotfiles repository and runs its install
+# script if one is found. Supports updating an existing clone.
+#
+# Prerequisites:
+# - SSH key deployed (handled by first-boot.sh)
+# - git installed
+# - DOTFILES_REPO set in config.conf
+#
+# Usage: ./dotfiles-setup.sh [--force]
+#   --force: Skip confirmation prompts, pass --force to install script
+#
+# Author: Andrew Rich <andrew.rich@gmail.com>
+# Created: 2026-02-17
+
+set -euo pipefail
+
+# Parse command line arguments
+FORCE=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --force)
+      FORCE=true
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [--force]"
+      exit 1
+      ;;
+  esac
+done
+
+# Configuration loading
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/../config/config.conf"
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  CONFIG_FILE="${SCRIPT_DIR}/config/config.conf"
+fi
+
+if [[ -f "${CONFIG_FILE}" ]]; then
+  # shellcheck source=/dev/null
+  source "${CONFIG_FILE}"
+else
+  echo "Error: Configuration file not found"
+  echo "Checked: ${SCRIPT_DIR}/../config/config.conf"
+  echo "Checked: ${SCRIPT_DIR}/config/config.conf"
+  exit 1
+fi
+
+# Derived variables
+HOSTNAME="${HOSTNAME_OVERRIDE:-${SERVER_NAME}}"
+HOSTNAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<<"${HOSTNAME}")"
+
+# Logging configuration
+LOG_DIR="${HOME}/.local/state"
+LOG_FILE="${LOG_DIR}/${HOSTNAME_LOWER}-app-setup.log"
+mkdir -p "${LOG_DIR}"
+
+# Logging functions
+log() {
+  local timestamp
+  timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+  echo "[${timestamp}] $*" >>"${LOG_FILE}"
+}
+
+show_log() {
+  echo "$*"
+  log "$*"
+}
+
+section() {
+  log "====== $* ======"
+}
+
+# Error collection
+COLLECTED_ERRORS=()
+CURRENT_SECTION="Dotfiles Setup"
+
+collect_error() {
+  local message="$1"
+  show_log "ERROR: ${message}"
+  COLLECTED_ERRORS+=("[${CURRENT_SECTION}] ${message}")
+}
+
+check_success() {
+  local exit_code=$1
+  local operation="$2"
+
+  if [[ ${exit_code} -eq 0 ]]; then
+    show_log "OK: ${operation}"
+    return 0
+  else
+    collect_error "${operation} failed with exit code ${exit_code}"
+    return 1
+  fi
+}
+
+# Dotfiles clone target
+readonly DOTFILES_DIR="${HOME}/.dotfiles"
+
+# Known install script names to search for
+readonly -a INSTALL_SCRIPTS=(
+  "install.sh"
+  "setup.sh"
+  "bootstrap.sh"
+)
+
+# Main execution
+main() {
+  section "Dotfiles Clone and Installation"
+  show_log "Starting dotfiles setup..."
+
+  # Check if DOTFILES_REPO is configured
+  if [[ -z "${DOTFILES_REPO:-}" ]]; then
+    show_log "DOTFILES_REPO not set in config - skipping dotfiles setup"
+    exit 0
+  fi
+
+  show_log "Dotfiles repo: ${DOTFILES_REPO}"
+  show_log "Clone target: ${DOTFILES_DIR}"
+
+  # Verify git is available
+  if ! command -v git &>/dev/null; then
+    collect_error "git not found - install via Homebrew first"
+    exit 1
+  fi
+
+  # Clone or update dotfiles
+  if [[ -d "${DOTFILES_DIR}" ]]; then
+    section "Updating Existing Dotfiles"
+    show_log "Dotfiles directory exists, pulling latest changes..."
+
+    local pull_exit=0
+    git -C "${DOTFILES_DIR}" pull >>"${LOG_FILE}" 2>&1 || pull_exit=$?
+    check_success "${pull_exit}" "Dotfiles pull" || true
+  else
+    section "Cloning Dotfiles Repository"
+
+    if [[ "${FORCE}" != true ]]; then
+      show_log ""
+      show_log "Will clone ${DOTFILES_REPO} to ${DOTFILES_DIR}"
+      show_log ""
+
+      read -r -n 1 -p "Proceed with dotfiles clone? (Y/n): " response
+      echo
+      case "${response}" in
+        [nN])
+          show_log "Dotfiles clone cancelled by user"
+          exit 0
+          ;;
+        *)
+          show_log "Proceeding with clone..."
+          ;;
+      esac
+    fi
+
+    show_log "Cloning dotfiles repository..."
+
+    local clone_exit=0
+    git clone "${DOTFILES_REPO}" "${DOTFILES_DIR}" >>"${LOG_FILE}" 2>&1 || clone_exit=$?
+
+    if ! check_success "${clone_exit}" "Dotfiles clone"; then
+      show_log "Ensure SSH key is deployed and has access to the repository"
+      exit 1
+    fi
+  fi
+
+  # Look for and run install script
+  section "Running Dotfiles Install Script"
+  local found_install_script=""
+
+  for script_name in "${INSTALL_SCRIPTS[@]}"; do
+    if [[ -f "${DOTFILES_DIR}/${script_name}" ]]; then
+      found_install_script="${DOTFILES_DIR}/${script_name}"
+      break
+    fi
+  done
+
+  # Also check for Makefile
+  if [[ -z "${found_install_script}" ]] && [[ -f "${DOTFILES_DIR}/Makefile" ]]; then
+    show_log "Found Makefile in dotfiles"
+
+    if command -v make &>/dev/null; then
+      show_log "Running make install..."
+      local make_exit=0
+      make -C "${DOTFILES_DIR}" install >>"${LOG_FILE}" 2>&1 || make_exit=$?
+      check_success "${make_exit}" "Dotfiles make install" || true
+    else
+      show_log "make not found - skipping Makefile execution"
+      log "Makefile found but make command not available"
+    fi
+  elif [[ -n "${found_install_script}" ]]; then
+    show_log "Found install script: $(basename "${found_install_script}")"
+
+    # Make executable if not already
+    chmod +x "${found_install_script}"
+
+    # Build command
+    local -a install_cmd=("${found_install_script}")
+    if [[ "${FORCE}" == true ]]; then
+      install_cmd+=("--force")
+    fi
+
+    show_log "Running: ${install_cmd[*]}"
+    local install_exit=0
+    "${install_cmd[@]}" >>"${LOG_FILE}" 2>&1 || install_exit=$?
+    check_success "${install_exit}" "Dotfiles install script" || true
+  else
+    show_log "No install script found in dotfiles (checked: ${INSTALL_SCRIPTS[*]}, Makefile)"
+    log "Dotfiles cloned but no install script to run - manual setup may be needed"
+  fi
+
+  # Summary
+  section "Dotfiles Setup Summary"
+  show_log "Dotfiles directory: ${DOTFILES_DIR}"
+
+  local file_count
+  file_count="$(find "${DOTFILES_DIR}" -maxdepth 1 -not -name ".git" -not -name "." | wc -l | tr -d ' ')"
+  show_log "Files in dotfiles: ${file_count}"
+
+  if [[ ${#COLLECTED_ERRORS[@]} -gt 0 ]]; then
+    show_log ""
+    show_log "Dotfiles setup completed with ${#COLLECTED_ERRORS[@]} error(s)"
+    exit 1
+  fi
+
+  show_log "Dotfiles setup completed successfully"
+}
+
+main "$@"

--- a/app-setup/node-setup.sh
+++ b/app-setup/node-setup.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+#
+# node-setup.sh - Node.js global package configuration
+#
+# This script configures npm global directory to avoid permission issues
+# and installs required global npm packages. Node.js itself is installed
+# via Homebrew (formulae.txt).
+#
+# Prerequisites:
+# - Node.js installed via Homebrew
+#
+# Usage: ./node-setup.sh [--force]
+#   --force: Skip confirmation prompts
+#
+# Author: Andrew Rich <andrew.rich@gmail.com>
+# Created: 2026-02-17
+
+set -euo pipefail
+
+# Parse command line arguments
+FORCE=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --force)
+      FORCE=true
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [--force]"
+      exit 1
+      ;;
+  esac
+done
+
+# Configuration loading
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/../config/config.conf"
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  CONFIG_FILE="${SCRIPT_DIR}/config/config.conf"
+fi
+
+if [[ -f "${CONFIG_FILE}" ]]; then
+  # shellcheck source=/dev/null
+  source "${CONFIG_FILE}"
+else
+  echo "Error: Configuration file not found"
+  echo "Checked: ${SCRIPT_DIR}/../config/config.conf"
+  echo "Checked: ${SCRIPT_DIR}/config/config.conf"
+  exit 1
+fi
+
+# Derived variables
+HOSTNAME="${HOSTNAME_OVERRIDE:-${SERVER_NAME}}"
+HOSTNAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<<"${HOSTNAME}")"
+
+# Logging configuration
+LOG_DIR="${HOME}/.local/state"
+LOG_FILE="${LOG_DIR}/${HOSTNAME_LOWER}-app-setup.log"
+mkdir -p "${LOG_DIR}"
+
+# Logging functions
+log() {
+  local timestamp
+  timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+  echo "[${timestamp}] $*" >>"${LOG_FILE}"
+}
+
+show_log() {
+  echo "$*"
+  log "$*"
+}
+
+section() {
+  log "====== $* ======"
+}
+
+# Error collection
+COLLECTED_ERRORS=()
+CURRENT_SECTION="Node.js Setup"
+
+collect_error() {
+  local message="$1"
+  show_log "ERROR: ${message}"
+  COLLECTED_ERRORS+=("[${CURRENT_SECTION}] ${message}")
+}
+
+check_success() {
+  local exit_code=$1
+  local operation="$2"
+
+  if [[ ${exit_code} -eq 0 ]]; then
+    show_log "OK: ${operation}"
+    return 0
+  else
+    collect_error "${operation} failed with exit code ${exit_code}"
+    return 1
+  fi
+}
+
+# Global npm packages to install
+readonly -a GLOBAL_PACKAGES=(
+  "eas-cli"
+  "npm-check-updates"
+)
+
+# npm global directory
+readonly NPM_GLOBAL_DIR="${HOME}/.npm-global"
+
+# Main execution
+main() {
+  section "Node.js Global Package Configuration"
+  show_log "Starting Node.js setup..."
+  log "NODE_VERSION config: ${NODE_VERSION:-not set}"
+
+  # Verify Node.js is installed
+  if ! command -v node &>/dev/null; then
+    collect_error "Node.js not found - install via Homebrew first (check formulae.txt)"
+    exit 1
+  fi
+
+  local node_version
+  node_version="$(node --version)"
+  show_log "Node.js version: ${node_version}"
+
+  if ! command -v npm &>/dev/null; then
+    collect_error "npm not found - Node.js installation may be incomplete"
+    exit 1
+  fi
+
+  local npm_version
+  npm_version="$(npm --version)"
+  show_log "npm version: ${npm_version}"
+
+  # Configure npm global directory
+  section "Configuring npm Global Directory"
+
+  if [[ ! -d "${NPM_GLOBAL_DIR}" ]]; then
+    show_log "Creating npm global directory: ${NPM_GLOBAL_DIR}"
+    mkdir -p "${NPM_GLOBAL_DIR}"
+  fi
+
+  show_log "Setting npm prefix to ${NPM_GLOBAL_DIR}"
+  npm config set prefix "${NPM_GLOBAL_DIR}"
+  log "npm prefix set to ${NPM_GLOBAL_DIR}"
+
+  # Add npm global bin to PATH in shell profiles if not already present
+  local npm_bin="${NPM_GLOBAL_DIR}/bin"
+  local path_line="export PATH=\"${npm_bin}:\${PATH}\""
+
+  for profile in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.bash_profile" "${HOME}/.profile"; do
+    if [[ -f "${profile}" ]]; then
+      if ! grep -q "${npm_bin}" "${profile}"; then
+        show_log "Adding npm global bin to PATH in ${profile}"
+        {
+          echo ""
+          echo "# npm global packages"
+          echo "${path_line}"
+        } >>"${profile}"
+        log "Updated ${profile} with npm global bin path"
+      else
+        log "npm global bin already in ${profile}"
+      fi
+    fi
+  done
+
+  # Add to current session
+  export PATH="${npm_bin}:${PATH}"
+
+  # Install global packages
+  section "Installing Global npm Packages"
+
+  if [[ "${FORCE}" != true ]]; then
+    show_log ""
+    show_log "The following global npm packages will be installed:"
+    for pkg in "${GLOBAL_PACKAGES[@]}"; do
+      show_log "  - ${pkg}"
+    done
+    show_log ""
+
+    read -r -n 1 -p "Proceed with package installation? (Y/n): " response
+    echo
+    case "${response}" in
+      [nN])
+        show_log "Package installation cancelled by user"
+        exit 0
+        ;;
+      *)
+        show_log "Proceeding with package installation..."
+        ;;
+    esac
+  fi
+
+  local install_exit
+  for pkg in "${GLOBAL_PACKAGES[@]}"; do
+    show_log "Installing ${pkg}..."
+
+    install_exit=0
+    npm install -g "${pkg}" >>"${LOG_FILE}" 2>&1 || install_exit=$?
+    check_success "${install_exit}" "${pkg} installation" || true
+  done
+
+  # Verification
+  section "Verifying Node.js Setup"
+  local verify_node verify_npm verify_prefix
+  verify_node="$(node --version)" || true
+  verify_npm="$(npm --version)" || true
+  verify_prefix="$(npm config get prefix)" || true
+  show_log "Node.js: ${verify_node}"
+  show_log "npm: ${verify_npm}"
+  show_log "npm prefix: ${verify_prefix}"
+
+  # Verify installed packages
+  for pkg in "${GLOBAL_PACKAGES[@]}"; do
+    # Get the command name (first part before any @version)
+    local cmd="${pkg%%@*}"
+    # eas-cli installs as 'eas', npm-check-updates installs as 'ncu'
+    case "${cmd}" in
+      eas-cli) cmd="eas" ;;
+      npm-check-updates) cmd="ncu" ;;
+      *) ;;
+    esac
+
+    if command -v "${cmd}" &>/dev/null; then
+      local pkg_version
+      pkg_version="$("${cmd}" --version 2>/dev/null || echo "installed")"
+      show_log "OK: ${pkg} (${pkg_version})"
+    else
+      collect_error "${pkg} command '${cmd}' not found after installation"
+    fi
+  done
+
+  if [[ ${#COLLECTED_ERRORS[@]} -gt 0 ]]; then
+    show_log ""
+    show_log "Node.js setup completed with ${#COLLECTED_ERRORS[@]} error(s)"
+    exit 1
+  fi
+
+  show_log "Node.js setup completed successfully"
+}
+
+main "$@"

--- a/app-setup/run-app-setup.sh
+++ b/app-setup/run-app-setup.sh
@@ -3,7 +3,6 @@
 # run-app-setup.sh - Application setup orchestrator for Mac Mini dev server
 #
 # This script runs all app-setup scripts in dependency order.
-# Phase 3 will add: xcode-setup.sh, android-setup.sh, node-setup.sh, dotfiles-setup.sh
 #
 # Unknown setup scripts are executed after the known ordered scripts.
 #
@@ -40,7 +39,11 @@ if [[ "${PWD}" != "${SCRIPT_DIR}" ]] || [[ "$(basename "${SCRIPT_DIR}")" != "app
 fi
 
 # Load server configuration
-CONFIG_FILE="${SCRIPT_DIR}/config/config.conf"
+CONFIG_FILE="${SCRIPT_DIR}/../config/config.conf"
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  # Fallback for deployed environment where config is copied into app-setup/
+  CONFIG_FILE="${SCRIPT_DIR}/config/config.conf"
+fi
 
 if [[ -f "${CONFIG_FILE}" ]]; then
   # shellcheck source=/dev/null
@@ -178,8 +181,12 @@ show_collected_issues() {
 }
 
 # Define optimal execution order with descriptions
-# Phase 3 will add: xcode-setup.sh, android-setup.sh, node-setup.sh, dotfiles-setup.sh
-declare -A SCRIPT_ORDER=()
+declare -A SCRIPT_ORDER=(
+  ["xcode-setup.sh"]="1:Xcode installation and configuration"
+  ["node-setup.sh"]="2:Node.js global package configuration"
+  ["android-setup.sh"]="3:Android SDK configuration"
+  ["dotfiles-setup.sh"]="4:Dotfiles clone and installation"
+)
 
 # Function to get all setup scripts
 get_setup_scripts() {

--- a/app-setup/xcode-setup.sh
+++ b/app-setup/xcode-setup.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+#
+# xcode-setup.sh - Xcode installation and configuration
+#
+# This script handles full Xcode installation via the Mac App Store,
+# license acceptance, developer path configuration, first launch setup,
+# and iOS simulator installation.
+#
+# Prerequisites:
+# - Apple ID must be signed into the App Store
+# - Command Line Tools already installed (handled by setup-command-line-tools.sh)
+# - mas (Mac App Store CLI) installed via Homebrew
+#
+# Usage: ./xcode-setup.sh [--force]
+#   --force: Skip confirmation prompts
+#
+# Author: Andrew Rich <andrew.rich@gmail.com>
+# Created: 2026-02-17
+
+set -euo pipefail
+
+# Parse command line arguments
+FORCE=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --force)
+      FORCE=true
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [--force]"
+      exit 1
+      ;;
+  esac
+done
+
+# Configuration loading
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/../config/config.conf"
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  CONFIG_FILE="${SCRIPT_DIR}/config/config.conf"
+fi
+
+if [[ -f "${CONFIG_FILE}" ]]; then
+  # shellcheck source=/dev/null
+  source "${CONFIG_FILE}"
+else
+  echo "Error: Configuration file not found"
+  echo "Checked: ${SCRIPT_DIR}/../config/config.conf"
+  echo "Checked: ${SCRIPT_DIR}/config/config.conf"
+  exit 1
+fi
+
+# Derived variables
+HOSTNAME="${HOSTNAME_OVERRIDE:-${SERVER_NAME}}"
+HOSTNAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<<"${HOSTNAME}")"
+
+# Logging configuration
+LOG_DIR="${HOME}/.local/state"
+LOG_FILE="${LOG_DIR}/${HOSTNAME_LOWER}-app-setup.log"
+mkdir -p "${LOG_DIR}"
+
+# Logging functions
+log() {
+  local timestamp
+  timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+  echo "[${timestamp}] $*" >>"${LOG_FILE}"
+}
+
+show_log() {
+  echo "$*"
+  log "$*"
+}
+
+section() {
+  log "====== $* ======"
+}
+
+# Error collection
+COLLECTED_ERRORS=()
+CURRENT_SECTION="Xcode Setup"
+
+collect_error() {
+  local message="$1"
+  show_log "ERROR: ${message}"
+  COLLECTED_ERRORS+=("[${CURRENT_SECTION}] ${message}")
+}
+
+check_success() {
+  local exit_code=$1
+  local operation="$2"
+
+  if [[ ${exit_code} -eq 0 ]]; then
+    show_log "OK: ${operation}"
+    return 0
+  else
+    collect_error "${operation} failed with exit code ${exit_code}"
+    return 1
+  fi
+}
+
+# Xcode App Store ID
+readonly XCODE_APP_ID="497799835"
+
+# Check if full Xcode is already installed
+is_xcode_installed() {
+  if [[ -d "/Applications/Xcode.app" ]]; then
+    local xcode_path
+    xcode_path="$(xcode-select -p 2>/dev/null || true)"
+    if [[ "${xcode_path}" == "/Applications/Xcode.app/Contents/Developer" ]]; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# Main execution
+main() {
+  section "Xcode Installation and Configuration"
+  show_log "Starting Xcode setup..."
+  log "XCODE_VERSION config: ${XCODE_VERSION:-latest}"
+
+  # Check if Xcode is already installed and configured
+  if is_xcode_installed; then
+    local installed_version
+    installed_version="$(xcodebuild -version 2>/dev/null | head -n 1 || echo "unknown")"
+    show_log "Xcode already installed: ${installed_version}"
+    show_log "Skipping installation"
+  else
+    # Verify mas is available
+    if ! command -v mas &>/dev/null; then
+      collect_error "mas (Mac App Store CLI) not found - install via Homebrew first"
+      exit 1
+    fi
+
+    # Warn about Apple ID requirement
+    show_log ""
+    show_log "IMPORTANT: Apple ID must be signed into the App Store for Xcode download."
+    show_log "Xcode is approximately 7GB and may take 30+ minutes to download."
+    show_log ""
+
+    if [[ "${FORCE}" != true ]]; then
+      read -r -n 1 -p "Proceed with Xcode installation? (Y/n): " response
+      echo
+      case "${response}" in
+        [nN])
+          show_log "Xcode installation cancelled by user"
+          exit 0
+          ;;
+        *)
+          show_log "Proceeding with Xcode installation..."
+          ;;
+      esac
+    fi
+
+    # Install Xcode via Mac App Store
+    section "Installing Xcode from App Store"
+    show_log "Installing Xcode via mas (this will take a while)..."
+
+    local install_exit=0
+    mas install "${XCODE_APP_ID}" || install_exit=$?
+
+    if [[ ${install_exit} -ne 0 ]]; then
+      collect_error "Xcode installation via mas failed (exit code: ${install_exit})"
+      show_log "Ensure you are signed into the App Store with an Apple ID"
+      exit 1
+    fi
+
+    show_log "OK: Xcode downloaded and installed from App Store"
+  fi
+
+  # Verify Xcode.app exists before proceeding
+  if [[ ! -d "/Applications/Xcode.app" ]]; then
+    collect_error "Xcode.app not found in /Applications after installation"
+    exit 1
+  fi
+
+  # Accept Xcode license
+  section "Accepting Xcode License"
+  show_log "Accepting Xcode license agreement..."
+
+  local license_exit=0
+  sudo xcodebuild -license accept 2>/dev/null || license_exit=$?
+  check_success "${license_exit}" "Xcode license acceptance" || true
+
+  # Set Xcode developer path
+  section "Configuring Xcode Developer Path"
+  show_log "Setting Xcode developer path..."
+
+  local path_exit=0
+  sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer || path_exit=$?
+  check_success "${path_exit}" "Xcode developer path configuration" || true
+
+  # Run first launch setup
+  section "Running Xcode First Launch Setup"
+  show_log "Running first launch setup (installing system components)..."
+
+  local firstlaunch_exit=0
+  xcodebuild -runFirstLaunch 2>/dev/null || firstlaunch_exit=$?
+  check_success "${firstlaunch_exit}" "Xcode first launch setup" || true
+
+  # Install iOS simulator
+  section "Installing iOS Simulator"
+  show_log "Downloading latest iOS simulator platform..."
+  show_log "This may take several minutes depending on connection speed."
+
+  local sim_exit=0
+  xcodebuild -downloadPlatform iOS 2>/dev/null || sim_exit=$?
+  check_success "${sim_exit}" "iOS simulator platform download" || true
+
+  # Verification
+  section "Verifying Xcode Installation"
+
+  local xcode_version
+  xcode_version="$(xcodebuild -version 2>/dev/null || echo "verification failed")"
+  show_log "Xcode version: ${xcode_version}"
+
+  local xcode_path
+  xcode_path="$(xcode-select -p 2>/dev/null || echo "not set")"
+  show_log "Developer path: ${xcode_path}"
+
+  # List available simulators
+  local sim_count
+  sim_count="$(xcrun simctl list devices available 2>/dev/null | grep -c "iPhone\|iPad" || echo "0")"
+  show_log "Available iOS simulators: ${sim_count}"
+
+  if [[ ${#COLLECTED_ERRORS[@]} -gt 0 ]]; then
+    show_log ""
+    show_log "Xcode setup completed with ${#COLLECTED_ERRORS[@]} error(s)"
+    exit 1
+  fi
+
+  show_log "Xcode setup completed successfully"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Create 4 app-setup scripts for development environment provisioning: `xcode-setup.sh` (Xcode via mas, license, simulators), `node-setup.sh` (npm global config, eas-cli), `android-setup.sh` (SDK components, licenses, ANDROID_HOME), `dotfiles-setup.sh` (clone & install)
- Fix `run-app-setup.sh` config path to prefer `../config/config.conf` with fallback for deployed environments
- Add execution order (`SCRIPT_ORDER`) for all 4 scripts; remove Phase 3 TODO placeholders

## Test plan
- [ ] All scripts pass `shellcheck --rcfile=.github/workflows/.shellcheckrc` (enable=all)
- [ ] All scripts pass `shfmt -d -i 2 -ci -bn`
- [ ] All scripts pass `bash -n` syntax check
- [ ] No `operator`/`OPERATOR` references in `app-setup/`
- [ ] `run-app-setup.sh` discovers and orders all 4 new scripts
- [ ] Each script runs standalone with `--force` (on target Mac Mini)

🤖 Generated with [Claude Code](https://claude.com/claude-code)