### PR TITLE
feat: holistic update — storage, Claude Code, dotfiles migration

### DIFF
--- a/app-setup/claude-setup.sh
+++ b/app-setup/claude-setup.sh
@@ -189,9 +189,12 @@ main() {
       show_log "Cloning claude-wrapper..."
       local clone_exit=0
 
-      # Remove stale directory if exists without .git
+      # Move aside stale directory if exists without .git
       if [[ -d "${wrapper_dir}" ]]; then
-        rm -rf "${wrapper_dir}"
+        local backup
+        backup="${wrapper_dir}.bak.$(date +%Y%m%d%H%M%S)"
+        mv "${wrapper_dir}" "${backup}"
+        show_log "Moved stale ${wrapper_dir} to ${backup}"
       fi
 
       git clone "${wrapper_repo}" "${wrapper_dir}" >>"${LOG_FILE}" 2>&1 || clone_exit=$?

--- a/app-setup/claude-setup.sh
+++ b/app-setup/claude-setup.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+#
+# claude-setup.sh - Claude Code CLI and wrapper installation
+#
+# Installs Claude Code CLI via the official installer and optionally
+# deploys the claude-wrapper for identity management and secrets.
+#
+# Prerequisites:
+# - curl installed
+# - git installed
+# - Node.js installed (for npm-based fallback)
+#
+# Usage: ./claude-setup.sh [--force]
+#   --force: Skip confirmation prompts
+#
+# Author: Andrew Rich <andrew.rich@gmail.com>
+# Created: 2026-03-27
+
+set -euo pipefail
+
+# Parse command line arguments
+FORCE=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --force)
+      FORCE=true
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [--force]"
+      exit 1
+      ;;
+  esac
+done
+
+# Configuration loading
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/../config/config.conf"
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  CONFIG_FILE="${SCRIPT_DIR}/config/config.conf"
+fi
+
+if [[ -f "${CONFIG_FILE}" ]]; then
+  # shellcheck source=/dev/null
+  source "${CONFIG_FILE}"
+else
+  echo "Error: Configuration file not found"
+  echo "Checked: ${SCRIPT_DIR}/../config/config.conf"
+  echo "Checked: ${SCRIPT_DIR}/config/config.conf"
+  exit 1
+fi
+
+# Derived variables
+HOSTNAME="${HOSTNAME_OVERRIDE:-${SERVER_NAME}}"
+HOSTNAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<<"${HOSTNAME}")"
+
+# Logging configuration
+LOG_DIR="${HOME}/.local/state"
+LOG_FILE="${LOG_DIR}/${HOSTNAME_LOWER}-app-setup.log"
+mkdir -p "${LOG_DIR}"
+
+# Logging functions
+log() {
+  local timestamp
+  timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+  echo "[${timestamp}] $*" >>"${LOG_FILE}"
+}
+
+show_log() {
+  echo "$*"
+  log "$*"
+}
+
+section() {
+  log "====== $* ======"
+}
+
+# Error collection
+COLLECTED_ERRORS=()
+CURRENT_SECTION="Claude Setup"
+
+collect_error() {
+  local message="$1"
+  show_log "ERROR: ${message}"
+  COLLECTED_ERRORS+=("[${CURRENT_SECTION}] ${message}")
+}
+
+check_success() {
+  local exit_code=$1
+  local operation="$2"
+
+  if [[ ${exit_code} -eq 0 ]]; then
+    show_log "OK: ${operation}"
+    return 0
+  else
+    collect_error "${operation} failed with exit code ${exit_code}"
+    return 1
+  fi
+}
+
+# Main execution
+main() {
+  section "Claude Code CLI Installation"
+  show_log "Starting Claude Code setup..."
+
+  # Install Claude Code CLI
+  CURRENT_SECTION="Claude Code CLI"
+
+  if command -v claude &>/dev/null; then
+    local current_version
+    current_version="$(claude --version 2>/dev/null || echo "unknown")"
+    show_log "Claude Code already installed: ${current_version}"
+
+    if [[ "${FORCE}" != true ]]; then
+      show_log "Use --force to update to latest version"
+    else
+      # Update to latest
+      show_log "Checking for updates..."
+      local update_exit=0
+      claude update --yes >>"${LOG_FILE}" 2>&1 || update_exit=$?
+      if [[ ${update_exit} -eq 0 ]]; then
+        local new_version
+        new_version="$(claude --version 2>/dev/null || echo "unknown")"
+        show_log "OK: Claude Code updated to ${new_version}"
+      else
+        show_log "Update check completed (may already be latest)"
+      fi
+    fi
+  else
+    show_log "Installing Claude Code CLI..."
+
+    # Ensure ~/.local/bin exists and is in PATH
+    mkdir -p "${HOME}/.local/bin"
+
+    # Use npm to install (simplest cross-platform method)
+    if command -v npm &>/dev/null; then
+      local install_exit=0
+      npm install -g @anthropic-ai/claude-code >>"${LOG_FILE}" 2>&1 || install_exit=$?
+
+      if [[ ${install_exit} -ne 0 ]]; then
+        show_log "npm install failed, trying curl installer..."
+        # Fallback to curl-based installer
+        local curl_exit=0
+        curl -fsSL https://claude.ai/install.sh | sh >>"${LOG_FILE}" 2>&1 || curl_exit=$?
+        check_success "${curl_exit}" "Claude Code installation (curl)"
+      else
+        check_success 0 "Claude Code installation (npm)"
+      fi
+    else
+      # No npm — use curl installer directly
+      local curl_exit=0
+      curl -fsSL https://claude.ai/install.sh | sh >>"${LOG_FILE}" 2>&1 || curl_exit=$?
+      check_success "${curl_exit}" "Claude Code installation (curl)"
+    fi
+
+    # Verify installation
+    if command -v claude &>/dev/null; then
+      local installed_version
+      installed_version="$(claude --version 2>/dev/null || echo "unknown")"
+      show_log "OK: Claude Code installed: ${installed_version}"
+    else
+      # Check if it landed in ~/.local/bin but PATH doesn't include it yet
+      if [[ -x "${HOME}/.local/bin/claude" ]]; then
+        show_log "OK: Claude Code installed at ~/.local/bin/claude"
+        show_log "Note: Add ~/.local/bin to PATH in your shell profile"
+      else
+        collect_error "Claude Code installation failed — binary not found"
+      fi
+    fi
+  fi
+
+  # Install claude-wrapper
+  CURRENT_SECTION="Claude Wrapper"
+  section "Claude Wrapper Installation"
+
+  local wrapper_repo="${CLAUDE_WRAPPER_REPO:-}"
+  if [[ -z "${wrapper_repo}" ]]; then
+    show_log "CLAUDE_WRAPPER_REPO not configured — skipping wrapper installation"
+  else
+    local wrapper_dir="${HOME}/.claude-wrapper"
+
+    if [[ -d "${wrapper_dir}/.git" ]]; then
+      show_log "Updating existing claude-wrapper..."
+      local pull_exit=0
+      git -C "${wrapper_dir}" pull --ff-only >>"${LOG_FILE}" 2>&1 || pull_exit=$?
+      check_success "${pull_exit}" "Claude wrapper update" || true
+    else
+      show_log "Cloning claude-wrapper..."
+      local clone_exit=0
+
+      # Remove stale directory if exists without .git
+      if [[ -d "${wrapper_dir}" ]]; then
+        rm -rf "${wrapper_dir}"
+      fi
+
+      git clone "${wrapper_repo}" "${wrapper_dir}" >>"${LOG_FILE}" 2>&1 || clone_exit=$?
+      if ! check_success "${clone_exit}" "Claude wrapper clone"; then
+        show_log "Ensure SSH key is deployed and has access to the repository"
+      fi
+    fi
+
+    # Create symlink for the wrapper
+    if [[ -f "${wrapper_dir}/bin/claude-wrapper" ]]; then
+      mkdir -p "${HOME}/.local/bin"
+      local wrapper_link="${HOME}/.local/bin/claude-wrapper"
+
+      if [[ -L "${wrapper_link}" ]] || [[ -f "${wrapper_link}" ]]; then
+        rm "${wrapper_link}"
+      fi
+      ln -s "${wrapper_dir}/bin/claude-wrapper" "${wrapper_link}"
+      chmod +x "${wrapper_dir}/bin/claude-wrapper"
+      show_log "OK: claude-wrapper symlinked to ${wrapper_link}"
+    else
+      collect_error "claude-wrapper binary not found at ${wrapper_dir}/bin/claude-wrapper"
+    fi
+  fi
+
+  # Summary
+  section "Claude Setup Summary"
+
+  if command -v claude &>/dev/null; then
+    show_log "Claude Code: $(claude --version 2>/dev/null || echo "installed")"
+  else
+    show_log "Claude Code: not in PATH"
+  fi
+
+  if [[ -L "${HOME}/.local/bin/claude-wrapper" ]]; then
+    show_log "Claude Wrapper: installed"
+  else
+    show_log "Claude Wrapper: not installed"
+  fi
+
+  if [[ ${#COLLECTED_ERRORS[@]} -gt 0 ]]; then
+    show_log ""
+    show_log "Claude setup completed with ${#COLLECTED_ERRORS[@]} error(s)"
+    exit 1
+  fi
+
+  show_log "Claude setup completed successfully"
+}
+
+main "$@"

--- a/app-setup/dotfiles-setup.sh
+++ b/app-setup/dotfiles-setup.sh
@@ -105,7 +105,8 @@ check_success() {
 
 # Dotfiles clone target — repo lives at ~/Developer/dotfiles (or configured path).
 # The repo's install.sh creates symlinks from ~/.config/<tool> -> repo/<tool>.
-readonly DOTFILES_DIR="${DOTFILES_DIR_OVERRIDE:-${HOME}/Developer/dotfiles}"
+# Override via DOTFILES_DIR in config.conf if needed.
+readonly DOTFILES_DIR="${DOTFILES_DIR:-${HOME}/Developer/dotfiles}"
 
 # Legacy clone location — older setup cloned directly to ~/.config
 readonly LEGACY_DOTFILES_DIR="${HOME}/.config"
@@ -163,17 +164,29 @@ main() {
     show_log "Migrating dotfiles from legacy location ${LEGACY_DOTFILES_DIR} to ${DOTFILES_DIR}..."
     mkdir -p "$(dirname "${DOTFILES_DIR}")"
 
-    # Move the repo — non-git files in ~/.config stay behind (app defaults)
+    # Clone from legacy location — non-git files in ~/.config stay behind
     local temp_dir
     temp_dir="$(mktemp -d)"
-    git clone "${LEGACY_DOTFILES_DIR}" "${temp_dir}/dotfiles" >>"${LOG_FILE}" 2>&1
+    local clone_exit=0
+    git clone "${LEGACY_DOTFILES_DIR}" "${temp_dir}/dotfiles" >>"${LOG_FILE}" 2>&1 || clone_exit=$?
+    if [[ ${clone_exit} -ne 0 ]]; then
+      rm -rf "${temp_dir}"
+      collect_error "Failed to clone from legacy dotfiles location"
+      exit 1
+    fi
+
     mv "${temp_dir}/dotfiles" "${DOTFILES_DIR}"
     rm -rf "${temp_dir}"
 
-    # Remove .git from legacy location so it's no longer treated as a repo
-    rm -rf "${LEGACY_DOTFILES_DIR}/.git"
-    show_log "OK: Migrated dotfiles repo to ${DOTFILES_DIR}"
-    log "Legacy .git removed from ${LEGACY_DOTFILES_DIR}"
+    # Only remove legacy .git after confirming new location has a working repo
+    if [[ -d "${DOTFILES_DIR}/.git" ]]; then
+      rm -rf "${LEGACY_DOTFILES_DIR}/.git"
+      show_log "OK: Migrated dotfiles repo to ${DOTFILES_DIR}"
+      log "Legacy .git removed from ${LEGACY_DOTFILES_DIR}"
+    else
+      collect_error "Migration failed — new dotfiles directory missing .git"
+      exit 1
+    fi
   fi
 
   if [[ -d "${DOTFILES_DIR}/.git" ]]; then

--- a/app-setup/dotfiles-setup.sh
+++ b/app-setup/dotfiles-setup.sh
@@ -103,9 +103,12 @@ check_success() {
   fi
 }
 
-# Dotfiles clone target — the repo IS the XDG config directory.
-# On a fresh Mac Mini, dotfiles intentionally overwrite any app defaults.
-readonly DOTFILES_DIR="${HOME}/.config"
+# Dotfiles clone target — repo lives at ~/Developer/dotfiles (or configured path).
+# The repo's install.sh creates symlinks from ~/.config/<tool> -> repo/<tool>.
+readonly DOTFILES_DIR="${DOTFILES_DIR_OVERRIDE:-${HOME}/Developer/dotfiles}"
+
+# Legacy clone location — older setup cloned directly to ~/.config
+readonly LEGACY_DOTFILES_DIR="${HOME}/.config"
 
 # Known install script names to search for
 readonly -a INSTALL_SCRIPTS=(
@@ -155,20 +158,27 @@ main() {
     esac
   fi
 
-  if [[ -d "${DOTFILES_DIR}" ]]; then
-    # Directory exists — either a working repo, a half-initialized repo from
-    # a previous failed run, or a plain directory with app defaults.
-    # git init is a no-op on an already-initialized repo, so this path
-    # handles all three cases. Force-checkout overwrites conflicting files
-    # (dotfiles intentionally replace app defaults in ~/.config).
-    show_log "Initializing dotfiles repo in ${DOTFILES_DIR}..."
+  # Migrate from legacy location (~/.config as the repo) to new layout
+  if [[ -d "${LEGACY_DOTFILES_DIR}/.git" ]] && [[ ! -d "${DOTFILES_DIR}/.git" ]]; then
+    show_log "Migrating dotfiles from legacy location ${LEGACY_DOTFILES_DIR} to ${DOTFILES_DIR}..."
+    mkdir -p "$(dirname "${DOTFILES_DIR}")"
 
-    local init_exit=0
-    git -C "${DOTFILES_DIR}" init >>"${LOG_FILE}" 2>&1 || init_exit=$?
-    if [[ ${init_exit} -ne 0 ]]; then
-      check_success "${init_exit}" "Dotfiles git init"
-      exit 1
-    fi
+    # Move the repo — non-git files in ~/.config stay behind (app defaults)
+    local temp_dir
+    temp_dir="$(mktemp -d)"
+    git clone "${LEGACY_DOTFILES_DIR}" "${temp_dir}/dotfiles" >>"${LOG_FILE}" 2>&1
+    mv "${temp_dir}/dotfiles" "${DOTFILES_DIR}"
+    rm -rf "${temp_dir}"
+
+    # Remove .git from legacy location so it's no longer treated as a repo
+    rm -rf "${LEGACY_DOTFILES_DIR}/.git"
+    show_log "OK: Migrated dotfiles repo to ${DOTFILES_DIR}"
+    log "Legacy .git removed from ${LEGACY_DOTFILES_DIR}"
+  fi
+
+  if [[ -d "${DOTFILES_DIR}/.git" ]]; then
+    # Repo already exists at new location — update it
+    show_log "Updating existing dotfiles repo in ${DOTFILES_DIR}..."
 
     # Idempotent remote setup
     if git -C "${DOTFILES_DIR}" remote get-url origin >>"${LOG_FILE}" 2>&1; then
@@ -191,8 +201,39 @@ main() {
     default_branch="${default_branch:-main}"
     log "Remote default branch: ${default_branch}"
 
-    # Create local branch tracking remote — force overwrites untracked files
-    # that conflict with the repo (e.g., app defaults already in ~/.config)
+    # Fast-forward to latest
+    local checkout_exit=0
+    git -C "${DOTFILES_DIR}" checkout -f -B "${default_branch}" "origin/${default_branch}" >>"${LOG_FILE}" 2>&1 || checkout_exit=$?
+
+    if ! check_success "${checkout_exit}" "Dotfiles sync"; then
+      show_log "Ensure SSH key is deployed and has access to the repository"
+      exit 1
+    fi
+  elif [[ -d "${DOTFILES_DIR}" ]]; then
+    # Directory exists but is not a git repo — init and set up
+    show_log "Initializing dotfiles repo in ${DOTFILES_DIR}..."
+
+    local init_exit=0
+    git -C "${DOTFILES_DIR}" init >>"${LOG_FILE}" 2>&1 || init_exit=$?
+    if [[ ${init_exit} -ne 0 ]]; then
+      check_success "${init_exit}" "Dotfiles git init"
+      exit 1
+    fi
+
+    git -C "${DOTFILES_DIR}" remote add origin "${DOTFILES_REPO}" >>"${LOG_FILE}" 2>&1
+
+    local fetch_exit=0
+    git -C "${DOTFILES_DIR}" fetch origin >>"${LOG_FILE}" 2>&1 || fetch_exit=$?
+    if [[ ${fetch_exit} -ne 0 ]]; then
+      check_success "${fetch_exit}" "Dotfiles fetch"
+      show_log "Ensure SSH key is deployed and has access to the repository"
+      exit 1
+    fi
+
+    local default_branch
+    default_branch="$(git -C "${DOTFILES_DIR}" remote show origin 2>>"${LOG_FILE}" | sed -n '/HEAD branch/s/.*: //p')"
+    default_branch="${default_branch:-main}"
+
     local checkout_exit=0
     git -C "${DOTFILES_DIR}" checkout -f -B "${default_branch}" "origin/${default_branch}" >>"${LOG_FILE}" 2>&1 || checkout_exit=$?
 
@@ -242,11 +283,8 @@ main() {
     # Make executable if not already
     chmod +x "${found_install_script}"
 
-    # Build command
+    # Build command (install.sh is idempotent, no --force needed)
     local -a install_cmd=("${found_install_script}")
-    if [[ "${FORCE}" == true ]]; then
-      install_cmd+=("--force")
-    fi
 
     show_log "Running: ${install_cmd[*]}"
     local install_exit=0

--- a/app-setup/run-app-setup.sh
+++ b/app-setup/run-app-setup.sh
@@ -182,10 +182,12 @@ show_collected_issues() {
 
 # Define optimal execution order with descriptions
 declare -A SCRIPT_ORDER=(
-  ["xcode-setup.sh"]="1:Xcode installation and configuration"
-  ["node-setup.sh"]="2:Node.js global package configuration"
-  ["android-setup.sh"]="3:Android SDK configuration"
-  ["dotfiles-setup.sh"]="4:Dotfiles clone and installation"
+  ["storage-setup.sh"]="1:External storage configuration for development"
+  ["xcode-setup.sh"]="2:Xcode installation and configuration"
+  ["node-setup.sh"]="3:Node.js global package configuration"
+  ["android-setup.sh"]="4:Android SDK configuration"
+  ["dotfiles-setup.sh"]="5:Dotfiles clone and installation"
+  ["claude-setup.sh"]="6:Claude Code CLI and wrapper installation"
 )
 
 # Function to get all setup scripts

--- a/app-setup/storage-setup.sh
+++ b/app-setup/storage-setup.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+#
+# storage-setup.sh - External storage configuration for development
+#
+# Configures an external drive for large development artifacts:
+# - Workspaces (project checkouts)
+# - iOS Simulator runtimes and devices
+# - Android AVD images
+# - Package manager caches (CocoaPods, Homebrew downloads)
+#
+# Creates symlinks from standard macOS locations to the external volume
+# so tools find their data where they expect it.
+#
+# Prerequisites:
+# - External volume mounted (configured via EXTERNAL_STORAGE_VOLUME)
+#
+# Usage: ./storage-setup.sh [--force]
+#   --force: Skip confirmation prompts
+#
+# Author: Andrew Rich <andrew.rich@gmail.com>
+# Created: 2026-03-27
+
+set -euo pipefail
+
+# Parse command line arguments
+FORCE=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --force)
+      FORCE=true
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [--force]"
+      exit 1
+      ;;
+  esac
+done
+
+# Configuration loading
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/../config/config.conf"
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  CONFIG_FILE="${SCRIPT_DIR}/config/config.conf"
+fi
+
+if [[ -f "${CONFIG_FILE}" ]]; then
+  # shellcheck source=/dev/null
+  source "${CONFIG_FILE}"
+else
+  echo "Error: Configuration file not found"
+  echo "Checked: ${SCRIPT_DIR}/../config/config.conf"
+  echo "Checked: ${SCRIPT_DIR}/config/config.conf"
+  exit 1
+fi
+
+# Derived variables
+HOSTNAME="${HOSTNAME_OVERRIDE:-${SERVER_NAME}}"
+HOSTNAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<<"${HOSTNAME}")"
+
+# Logging configuration
+LOG_DIR="${HOME}/.local/state"
+LOG_FILE="${LOG_DIR}/${HOSTNAME_LOWER}-app-setup.log"
+mkdir -p "${LOG_DIR}"
+
+# Logging functions
+log() {
+  local timestamp
+  timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+  echo "[${timestamp}] $*" >>"${LOG_FILE}"
+}
+
+show_log() {
+  echo "$*"
+  log "$*"
+}
+
+section() {
+  log "====== $* ======"
+}
+
+# Error collection
+COLLECTED_ERRORS=()
+CURRENT_SECTION="Storage Setup"
+
+collect_error() {
+  local message="$1"
+  show_log "ERROR: ${message}"
+  COLLECTED_ERRORS+=("[${CURRENT_SECTION}] ${message}")
+}
+
+check_success() {
+  local exit_code=$1
+  local operation="$2"
+
+  if [[ ${exit_code} -eq 0 ]]; then
+    show_log "OK: ${operation}"
+    return 0
+  else
+    collect_error "${operation} failed with exit code ${exit_code}"
+    return 1
+  fi
+}
+
+# Ensure a symlink exists from source to target.
+# If source is a real directory, moves its contents to target first.
+ensure_symlink() {
+  local link_path="$1"
+  local target_path="$2"
+  local description="$3"
+
+  # Target directory must exist
+  if [[ ! -d "${target_path}" ]]; then
+    mkdir -p "${target_path}"
+    log "Created directory: ${target_path}"
+  fi
+
+  if [[ -L "${link_path}" ]]; then
+    local existing_target
+    existing_target="$(readlink "${link_path}")"
+    if [[ "${existing_target}" == "${target_path}" ]]; then
+      show_log "OK: ${description} symlink already correct"
+      return 0
+    else
+      show_log "Updating ${description} symlink: ${existing_target} -> ${target_path}"
+      rm "${link_path}"
+    fi
+  elif [[ -d "${link_path}" ]]; then
+    # Real directory exists — migrate contents
+    show_log "Migrating existing ${description} to external storage..."
+    local file_count
+    file_count="$(find "${link_path}" -maxdepth 1 -mindepth 1 | wc -l | tr -d ' ')"
+    if [[ "${file_count}" -gt 0 ]]; then
+      rsync -a "${link_path}/" "${target_path}/" >>"${LOG_FILE}" 2>&1
+      log "Migrated ${file_count} items from ${link_path} to ${target_path}"
+    fi
+    rm -rf "${link_path}"
+  fi
+
+  # Create parent directory if needed
+  local parent_dir
+  parent_dir="$(dirname "${link_path}")"
+  if [[ ! -d "${parent_dir}" ]]; then
+    mkdir -p "${parent_dir}"
+  fi
+
+  ln -s "${target_path}" "${link_path}"
+  show_log "OK: ${description} -> ${target_path}"
+}
+
+# Main execution
+main() {
+  section "External Storage Configuration"
+
+  # Validate external storage volume
+  local volume="${EXTERNAL_STORAGE_VOLUME:-}"
+  if [[ -z "${volume}" ]]; then
+    show_log "EXTERNAL_STORAGE_VOLUME not configured — skipping storage setup"
+    show_log "Set EXTERNAL_STORAGE_VOLUME in config.conf to enable"
+    exit 0
+  fi
+
+  if [[ ! -d "${volume}" ]]; then
+    collect_error "External volume not mounted: ${volume}"
+    show_log "Ensure the drive is connected and mounted before running storage setup"
+    exit 1
+  fi
+
+  # Check volume is writable
+  if [[ ! -w "${volume}" ]]; then
+    collect_error "External volume not writable: ${volume}"
+    exit 1
+  fi
+
+  local volume_info
+  volume_info="$(df -h "${volume}" 2>/dev/null | tail -1)"
+  show_log "External volume: ${volume}"
+  show_log "Volume info: ${volume_info}"
+
+  if [[ "${FORCE}" != true ]]; then
+    show_log ""
+    show_log "This will configure external storage at ${volume} for:"
+    show_log "  - Workspaces (~/Developer)"
+    show_log "  - iOS Simulator runtimes"
+    show_log "  - Android AVD images"
+    show_log "  - Package caches"
+    show_log ""
+    show_log "Existing data in these locations will be migrated."
+    show_log ""
+
+    read -r -n 1 -p "Proceed with storage configuration? (Y/n): " response
+    echo
+    case "${response}" in
+      [nN])
+        show_log "Storage configuration cancelled by user"
+        exit 0
+        ;;
+      *)
+        show_log "Proceeding with storage configuration..."
+        ;;
+    esac
+  fi
+
+  # Create top-level directories on external volume
+  CURRENT_SECTION="Directory Creation"
+  section "Creating directory structure on ${volume}"
+
+  local -a STORAGE_DIRS=(
+    "${volume}/Workspaces"
+    "${volume}/Simulators"
+    "${volume}/Android/avd"
+    "${volume}/Caches/CocoaPods"
+    "${volume}/Caches/Homebrew"
+  )
+
+  for dir in "${STORAGE_DIRS[@]}"; do
+    if [[ ! -d "${dir}" ]]; then
+      mkdir -p "${dir}"
+      show_log "Created: ${dir}"
+    else
+      show_log "OK: ${dir} exists"
+    fi
+  done
+
+  # Set up symlinks
+  CURRENT_SECTION="Symlink Configuration"
+  section "Configuring symlinks"
+
+  # ~/Developer -> external Workspaces
+  ensure_symlink \
+    "${HOME}/Developer" \
+    "${volume}/Workspaces" \
+    "Developer workspace"
+
+  # iOS Simulator devices -> external storage
+  # CoreSimulator stores device data here (runtimes are managed separately)
+  ensure_symlink \
+    "${HOME}/Library/Developer/CoreSimulator/Devices" \
+    "${volume}/Simulators/Devices" \
+    "iOS Simulator devices"
+
+  # Xcode derived data (build caches, can be very large)
+  ensure_symlink \
+    "${HOME}/Library/Developer/Xcode/DerivedData" \
+    "${volume}/Caches/DerivedData" \
+    "Xcode DerivedData"
+
+  # Android AVD images
+  ensure_symlink \
+    "${HOME}/.android/avd" \
+    "${volume}/Android/avd" \
+    "Android AVD images"
+
+  # CocoaPods cache
+  ensure_symlink \
+    "${HOME}/Library/Caches/CocoaPods" \
+    "${volume}/Caches/CocoaPods" \
+    "CocoaPods cache"
+
+  # Homebrew download cache
+  ensure_symlink \
+    "${HOME}/Library/Caches/Homebrew" \
+    "${volume}/Caches/Homebrew" \
+    "Homebrew download cache"
+
+  # Verification
+  CURRENT_SECTION="Verification"
+  section "Verifying storage configuration"
+
+  for dir in "${HOME}/Developer" \
+    "${HOME}/Library/Developer/CoreSimulator/Devices" \
+    "${HOME}/Library/Developer/Xcode/DerivedData" \
+    "${HOME}/.android/avd" \
+    "${HOME}/Library/Caches/CocoaPods" \
+    "${HOME}/Library/Caches/Homebrew"; do
+    if [[ -L "${dir}" ]]; then
+      local target
+      target="$(readlink "${dir}")"
+      if [[ -d "${target}" ]]; then
+        show_log "OK: ${dir} -> ${target}"
+      else
+        collect_error "Symlink target missing: ${dir} -> ${target}"
+      fi
+    else
+      collect_error "Expected symlink not found: ${dir}"
+    fi
+  done
+
+  # Report disk usage
+  show_log ""
+  show_log "External storage usage:"
+  du -sh "${volume}"/* 2>/dev/null | while IFS= read -r line; do
+    show_log "  ${line}"
+  done
+
+  if [[ ${#COLLECTED_ERRORS[@]} -gt 0 ]]; then
+    show_log ""
+    show_log "Storage setup completed with ${#COLLECTED_ERRORS[@]} error(s)"
+    exit 1
+  fi
+
+  show_log "Storage setup completed successfully"
+}
+
+main "$@"

--- a/config/config.conf.template
+++ b/config/config.conf.template
@@ -8,7 +8,7 @@ SERVER_NAME="macmini"
 # 1Password configuration
 ONEPASSWORD_VAULT="personal"
 ONEPASSWORD_APPLEID_ITEM="Apple"
-ONEPASSWORD_TIMEMACHINE_ITEM="TimeMachine NAS"
+ONEPASSWORD_TIMEMACHINE_ITEM="Synology NAS - TimeMachine"
 SSH_KEY_ITEM="SSH Keys"
 
 # Monitoring

--- a/config/config.conf.template
+++ b/config/config.conf.template
@@ -20,6 +20,13 @@ ANDROID_SDK_VERSION="34"
 NODE_VERSION="lts"
 XCODE_VERSION=""  # Empty = latest from App Store
 
+# External storage (optional — leave empty to skip)
+# Mount point of external drive for workspaces, simulators, and caches
+EXTERNAL_STORAGE_VOLUME=""
+
+# Claude Code (optional — leave empty to skip wrapper)
+CLAUDE_WRAPPER_REPO=""
+
 # Terminal configuration (optional)
 TERMINAL_PROFILE_FILE=""
 USE_ITERM2="false"

--- a/config/formulae.txt
+++ b/config/formulae.txt
@@ -40,8 +40,15 @@ yarn
 pnpm
 
 # Python (for various tooling)
-python@3.12
+python@3.13
 pipx
+pre-commit
+
+# Search and navigation
+fzf
+
+# Task runner
+task
 
 # Network tools (retained)
 openssh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ SERVER_NAME="macmini"
 # 1Password configuration
 ONEPASSWORD_VAULT="personal"
 ONEPASSWORD_APPLEID_ITEM="Apple"
-ONEPASSWORD_TIMEMACHINE_ITEM="TimeMachine NAS"
+ONEPASSWORD_TIMEMACHINE_ITEM="Synology NAS - TimeMachine"
 SSH_KEY_ITEM="SSH Keys"
 
 # Development configuration
@@ -53,7 +53,7 @@ The system uses 1Password for initial credential retrieval during setup preparat
 
 **ONEPASSWORD_TIMEMACHINE_ITEM**: Login item for Time Machine backup credentials
 
-- **Default**: "TimeMachine NAS"
+- **Default**: "Synology NAS - TimeMachine"
 - **Requirements**: Login item with username, password, and URL field
 
 **ONEPASSWORD_APPLEID_ITEM**: Login item for Apple ID credentials

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -29,7 +29,7 @@ HOSTNAME_OVERRIDE=""
 ONEPASSWORD_VAULT="personal"
 
 # 1Password item names (customizable)
-ONEPASSWORD_TIMEMACHINE_ITEM="TimeMachine NAS"
+ONEPASSWORD_TIMEMACHINE_ITEM="Synology NAS - TimeMachine"
 ONEPASSWORD_APPLEID_ITEM="Apple"
 SSH_KEY_ITEM="SSH Keys"
 ```

--- a/docs/setup/prep-airdrop.md
+++ b/docs/setup/prep-airdrop.md
@@ -37,7 +37,7 @@ Create these Login items in your 1Password vault before running the prep script:
 - **Apple ID**: Your Apple ID for system setup
 - **SSH Keys**: SSH key material for deployment
 
-Item titles should match your `config.conf` settings (defaults: "TimeMachine NAS", "Apple", "SSH Keys").
+Item titles should match your `config.conf` settings (defaults: "Synology NAS - TimeMachine", "Apple", "SSH Keys").
 
 ## Running AirDrop Prep
 
@@ -207,7 +207,7 @@ Check that item titles exactly match your `config.conf` settings:
 op item list --vault "personal"
 
 # Check specific item
-op item get "TimeMachine NAS" --vault "personal"
+op item get "Synology NAS - TimeMachine" --vault "personal"
 ```
 
 ### TouchID Sudo Configuration

--- a/prep-airdrop.sh
+++ b/prep-airdrop.sh
@@ -316,8 +316,7 @@ copy_dir_with_manifest() {
   local dest_dir_full="${OUTPUT_PATH}/${dest_dir_relative}"
 
   # Prepare array of exception dirs if except_dirs_string is non-empty
-  local IFS='|'
-  read -r -a except_dirs <<<"${except_dirs_string}"
+  IFS='|' read -r -a except_dirs <<<"${except_dirs_string}"
 
   if [[ -d "${source_dir}" ]]; then
     mkdir -p "${dest_dir_full}"


### PR DESCRIPTION
## Summary
- Add `storage-setup.sh` to configure external drives (2TB) for workspaces, simulator runtimes, DerivedData, AVDs, and package caches via symlinks
- Add `claude-setup.sh` for Claude Code CLI and claude-wrapper installation
- Update `dotfiles-setup.sh` to support the new `~/Developer/dotfiles` symlink model with automatic migration from legacy `~/.config` repo layout
- Update `formulae.txt` (Python 3.13, fzf, pre-commit, task) and config template with new `EXTERNAL_STORAGE_VOLUME` and `CLAUDE_WRAPPER_REPO` variables
- Fix pre-existing Semgrep IFS-tampering finding in `prep-airdrop.sh`
- Harden migration/cleanup paths per code review (guard against partial failures, backup instead of rm -rf)

## Verified on MIMOLETTE
All scripts run and verified on the target server:
- 6 storage symlinks created and verified (Developer, Simulators, DerivedData, AVDs, CocoaPods, Homebrew caches)
- Dotfiles migrated from legacy `~/.config` to `~/Developer/dotfiles`, install.sh ran, all symlinks healthy
- Claude Code v2.1.86 installed, claude-wrapper cloned and symlinked
- All dev tools verified: Node 25.8, Xcode 26.3, Git 2.53

## Test plan
- [x] shellcheck clean (all warnings resolved)
- [x] Semgrep clean
- [x] Code review (both reviewers) passed
- [x] `storage-setup.sh --force` on MIMOLETTE — all symlinks verified
- [x] `dotfiles-setup.sh --force` — migration + install.sh succeeded
- [x] `claude-setup.sh --force` — CLI + wrapper installed
- [x] `dotfiles install.sh --repair` — all symlinks healthy
- [ ] CI workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)