### PR TITLE
feat: add ci-workflows plugin to setup

### DIFF
--- a/app-setup/claude-setup.sh
+++ b/app-setup/claude-setup.sh
@@ -420,6 +420,7 @@ PLIST
       "frontend-mobile-development@claude-code-workflows"
       "code-critic@smartwatermelon-marketplace"
       "react-native-3d@smartwatermelon-marketplace"
+      "ci-workflows@smartwatermelon-marketplace"
       "frontend-design@claude-code-plugins"
     )
 


### PR DESCRIPTION
## Summary
- Adds `ci-workflows@smartwatermelon-marketplace` to the plugin install list in `claude-setup.sh`
- This is the new home of the `/post-push-loop` skill (smartwatermelon/smartwatermelon-marketplace#11)

## Test plan
- [ ] Run `claude-setup.sh` on MIMOLETTE — verify ci-workflows plugin is installed
- [ ] `/post-push-loop` recognized after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)