### PR TITLE
docs: update README and SPEC for plugins and post-push-loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ Automated setup for an Apple Silicon Mac Mini as a mobile development build serv
 3. **On Mac Mini desktop** (not SSH): `cd ~/Downloads/macmini-setup && ./first-boot.sh`
 4. **On Mac Mini**: `cd ~/app-setup && ./run-app-setup.sh` (installs dev tools)
 
-**Result**: Dev server at `your-server-name.local`, ready for builds. Run `claude auth login` post-setup to enable cloud-synced MCPs (Sentry, Gmail, Calendar).
+**Post-setup** (manual):
+
+1. `claude auth login` (enables cloud-synced MCPs: Sentry, Gmail, Calendar)
+2. `gh auth login` (enables `/post-push-loop` CI monitoring)
+
+**Result**: Dev server at `your-server-name.local`, ready for builds.
 
 More detail in [Prerequisites](docs/prerequisites.md) and [Environment Variables](docs/environment-variables.md).
 
@@ -34,7 +39,9 @@ Three phases, two machines.
 
 **Phase 2** (`first-boot.sh`, on the Mac Mini): Validates the hardware fingerprint, imports the keychain, runs 15+ setup modules (SSH, Homebrew, FileVault, Time Machine, etc). Has to be run from the local desktop, not SSH.
 
-**Phase 3** (`run-app-setup.sh`, on the Mac Mini): Discovers and runs all `*-setup.sh` scripts in dependency order -- Xcode, Node.js, Android SDK, and dotfiles.
+**Phase 3** (`run-app-setup.sh`, on the Mac Mini): Discovers and runs
+all `*-setup.sh` scripts in dependency order -- Xcode, Node.js,
+Android SDK, dotfiles, Claude Code (CLI + plugins + MCPs), and storage.
 
 ### Configuration flow
 
@@ -130,7 +137,9 @@ See [Prerequisites Guide](docs/prerequisites.md) for validation commands.
 │   ├── xcode-setup.sh            # Xcode via mas, license, simulators
 │   ├── node-setup.sh             # npm global config, eas-cli
 │   ├── android-setup.sh          # SDK components, licenses, ANDROID_HOME
-│   └── dotfiles-setup.sh         # Clone repo, run install script
+│   ├── dotfiles-setup.sh         # Clone repo, run install script
+│   ├── claude-setup.sh           # CLI, plugins, MCP servers, post-push-loop
+│   └── storage-setup.sh          # External storage configuration
 ├── scripts/
 │   └── server/
 │       ├── first-boot.sh          # Main provisioning script (15+ modules)

--- a/SPEC.md
+++ b/SPEC.md
@@ -227,6 +227,18 @@ Note: Xcode installed via App Store or mas CLI, not Homebrew cask.
    - Clone dotfiles repo
    - Create symlinks
    - Source configuration
+5. Create `app-setup/claude-setup.sh`
+   - Install Claude Code CLI
+   - Clone claude-config repo (`~/.claude`)
+   - Register plugin marketplaces (superpowers, claude-code-workflows,
+     smartwatermelon, claude-code-plugins, claude-plugins-official)
+   - Install plugins (superpowers, ci-workflows, code-critic, etc.)
+   - Setup MCP servers (Context7, headroom)
+   - Verify GitHub CLI authentication
+   - Verify post-push-loop readiness
+6. Create `app-setup/storage-setup.sh`
+   - Configure external storage volume
+   - Set up Time Machine (optional)
 
 ### Phase 4: Integration and Testing
 
@@ -292,8 +304,13 @@ Script should verify:
 - [ ] Dotfiles linked and shell configured
 - [ ] Homebrew doctor passes
 - [ ] `claude mcp list` shows context7 and headroom connected
-- [ ] `claude auth login` completed (enables cloud-synced MCPs: Sentry, Gmail, Calendar, etc.)
-- [ ] `gh auth status` succeeds (required for `/post-push-loop` CI monitoring)
+- [ ] `claude plugins marketplace list` shows all 5 marketplaces
+- [ ] `claude plugins list` shows installed plugins
+  (superpowers, ci-workflows, code-critic, etc.)
+- [ ] `claude auth login` completed
+  (enables cloud-synced MCPs: Sentry, Gmail, Calendar, etc.)
+- [ ] `gh auth status` succeeds
+  (required for `/post-push-loop` CI monitoring)
 - [ ] `~/.claude/scripts/post-push-status.sh` exists and is executable
 - [ ] `~/.config/git/hooks/pre-push` contains `POSTPUSH_LOOP` support
 


### PR DESCRIPTION
## Summary
- README: add `claude-setup.sh` and `storage-setup.sh` to file tree, update Phase 3 description, add post-setup manual steps (`claude auth login`, `gh auth login`)
- SPEC: add `claude-setup.sh` and `storage-setup.sh` to Implementation Phases, expand Post-Setup Validation with plugin marketplace and plugin verification checks

## Test plan
- [ ] Verify README file tree matches actual `app-setup/` directory
- [ ] Verify SPEC validation checklist covers all `claude-setup.sh` outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)