### PR TITLE
chore: sanitize PII for public repo readiness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ hostname
 sw_vers
 ```
 
-- If hostname is **NOT** a known server name (TILSIT, MIMOLETTE): you are on the **development Mac**
+- If hostname is **NOT** a known server name (listed in your `config.conf` as `SERVER_NAME`): you are on the **development Mac**
   - Safe: shellcheck, linting, editing scripts, `prep-airdrop.sh`
   - FORBIDDEN: running setup scripts (`first-boot.sh`, `setup-*.sh`), testing system services
 - If hostname **IS** a known server name: you are on the **target build server**
@@ -49,21 +49,21 @@ op vault list
 - After a failed commit, check `head -6 .git/last-review-result.log` to see the VERDICT; fix shellcheck issues, then re-add and recommit
 - `claude --version` inside `$()` in shell scripts always triggers SC2155 — use `local ver; ver=$(claude --version 2>/dev/null || echo 'installed'); show_log "Claude Code: $ver"`
 
-### SSH PATH on MIMOLETTE
+### SSH PATH on Target Server
 
 *~1,200 tokens/session saved*
 
-- Non-login SSH shells on MIMOLETTE do NOT have Homebrew or pipx in PATH
+- Non-login SSH shells on the target server do NOT have Homebrew or pipx in PATH
 - Always prefix SSH commands with: `export PATH="/opt/homebrew/bin:$HOME/.local/bin:$PATH"`
-- `brew` is at `/opt/homebrew/bin/brew` on MIMOLETTE (Apple Silicon)
+- `brew` is at `/opt/homebrew/bin/brew` on Apple Silicon targets
 
 ### SSH Access
 
 *~800 tokens/session saved*
 
-- The server is **MIMOLETTE** (Mac Mini), accessed as `andrewrich@mimolette.local` — NOT `mimolette` (bare hostname fails with 'Could not resolve hostname')
-- Always use `mimolette.local` in SSH commands
-- SSH has passwordless access and sudo on MIMOLETTE
+- The target server (Mac Mini) is accessed as `<user>@<server>.local` — NOT bare hostname (fails with 'Could not resolve hostname')
+- Always use `<server>.local` (mDNS) in SSH commands
+- SSH has passwordless key-based access and sudo on the target server
 
 ### File Read Before Write
 
@@ -77,7 +77,7 @@ op vault list
 *~700 tokens/session saved*
 
 - Headroom is installed via pipx as `headroom-ai` and requires extra dependencies: `pipx inject headroom-ai httpx[http2] h2`
-- Headroom LaunchAgent plist is at `~/Library/LaunchAgents/com.headroom.proxy.plist`; must be deployed to MIMOLETTE for `ANTHROPIC_BASE_URL` to work
+- Headroom LaunchAgent plist is at `~/Library/LaunchAgents/com.headroom.proxy.plist`; must be deployed to the target server for `ANTHROPIC_BASE_URL` to work
 - Use `mcp__headroom__headroom_retrieve` (not `headroom_retrieve`) as the MCP tool name
 
 ### Git Merge Workflow

--- a/SPEC.md
+++ b/SPEC.md
@@ -18,7 +18,7 @@ Forked from [mac-server-setup](https://github.com/smartwatermelon/mac-server-set
 | --- | --- |
 | Hardware | M4 Mac Mini, 16GB unified memory, 512GB SSD |
 | macOS | 15.x (Sequoia) or later |
-| Primary user | `andrewrich` (existing Apple Account, created during macOS setup) |
+| Primary user | `<admin-user>` (existing Apple Account, created during macOS Setup Assistant) |
 | Access methods | SSH (primary), Synergy, HDMI/KVM (secondary) |
 
 ## Architecture Decisions
@@ -67,7 +67,7 @@ Forked from [mac-server-setup](https://github.com/smartwatermelon/mac-server-set
 
 **Original**: Creates new `operator` user on fresh macOS install, configures automatic login.
 
-**New**: Assumes `andrewrich` user already exists (created during macOS Setup Assistant with Apple Account). Script configures existing user rather than creating one.
+**New**: Assumes the admin user already exists (created during macOS Setup Assistant with Apple Account). Script configures the existing user rather than creating one.
 
 This simplifies the flow:
 

--- a/config/config.conf.template
+++ b/config/config.conf.template
@@ -6,16 +6,16 @@
 SERVER_NAME="macmini"
 
 # 1Password configuration
-ONEPASSWORD_VAULT="personal"
-ONEPASSWORD_APPLEID_ITEM="Apple"
-ONEPASSWORD_TIMEMACHINE_ITEM="Synology NAS - TimeMachine"
-SSH_KEY_ITEM="SSH Keys"
+ONEPASSWORD_VAULT="Your-Vault-Name"
+ONEPASSWORD_APPLEID_ITEM="Your-AppleID-Item"
+ONEPASSWORD_TIMEMACHINE_ITEM="Your-TimeMachine-Item"
+SSH_KEY_ITEM="Your-SSH-Key-Item"
 
 # Monitoring
 MONITORING_EMAIL="your-email@example.com"
 
 # Development configuration
-DOTFILES_REPO="git@github.com:smartwatermelon/dotfiles.git"
+DOTFILES_REPO="git@github.com:YOUR_USER/dotfiles.git"
 ANDROID_SDK_VERSION="34"
 NODE_VERSION="lts"
 XCODE_VERSION=""  # Empty = latest from App Store


### PR DESCRIPTION
## Summary
- Replace real server hostnames (MIMOLETTE, TILSIT), SSH access details (`andrewrich@mimolette.local`), and machine topology with generic placeholders in CLAUDE.md
- Replace hardcoded `andrewrich` username with `<admin-user>` in SPEC.md
- Replace real 1Password vault/item names and dotfiles repo URL with placeholder values in config.conf.template

**Note:** Git history was also rewritten via `git filter-repo` to purge `docs/pia-split-tunnel-bug.md` which contained a home public IP, VPN exit IP, and internal subnet. Main was force-pushed separately.

## Context
Security audit to prepare this repo for public visibility. All script logic and functionality is unchanged — only docs and the config template were affected.

## Test plan
- [ ] Verify no real hostnames remain: `git grep -i 'mimolette\|tilsit\|asiago'`
- [ ] Verify no IPs in history: `git log --all -p -S '174.31.0.47'`
- [ ] Verify config template has placeholder values
- [ ] Verify scripts still source config.conf correctly (template structure unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)