### PR TITLE
feat(first-boot): keep login keychain unlocked on headless targets

### DIFF
--- a/scripts/server/first-boot.sh
+++ b/scripts/server/first-boot.sh
@@ -482,6 +482,18 @@ import_external_keychain_credentials() {
     show_log "⚠️ 1Password service account token not found in external keychain (optional)"
   fi
 
+  # Configure login keychain for headless operation
+  # Mac Mini dev servers don't have GUI auto-login (iCloud + TouchID accounts
+  # can't use it), so the keychain starts locked on reboot. Disable the idle
+  # timeout so once unlocked (manually or via console login), it stays unlocked
+  # until sleep. This is what lets claude-wrapper read OP_SERVICE_ACCOUNT_TOKEN
+  # from the Keychain without re-prompting.
+  if security set-keychain-settings -l -u "${HOME}/Library/Keychains/login.keychain-db"; then
+    show_log "✅ Login keychain configured: lock-on-sleep, no idle timeout"
+  else
+    collect_warning "Failed to configure login keychain lock behavior — may re-lock after idle"
+  fi
+
   return 0
 }
 


### PR DESCRIPTION
## Summary

Follow-up to smartwatermelon/mac-dev-server-setup#27. Mac Mini dev servers can't use GUI auto-login (iCloud + TouchID accounts disallow it), so the login keychain starts locked every reboot. Without the idle-timeout setting, even after a manual unlock it would re-lock during idle and break \`claude-wrapper\`'s Keychain-backed token fetch.

Adds \`security set-keychain-settings -l -u login.keychain-db\` to the end of \`import_external_keychain_credentials\` so once the admin unlocks the keychain (console login or manual \`security unlock-keychain\`), it stays unlocked until sleep.

## How this was discovered

During Phase 4 verification on MIMOLETTE after smartwatermelon/mac-dev-server-setup#27 merged, \`claude-wrapper\` appeared broken with \`op: failed to DecodeSACredentials: unexpected end of JSON input\`. Root cause was the login keychain being locked — \`security find-generic-password\` silently returned empty.

## Test plan

- [x] \`shellcheck -S info scripts/server/first-boot.sh\` clean
- [x] Verified manually on MIMOLETTE (\`security set-keychain-settings -l -u ...\` → \`show-keychain-info\` reports "lock-on-sleep no-timeout")
- [ ] Next fresh provisioning run: confirm the setting is applied and persists across reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)