### PR TITLE
chore: address non-blocking review nits from #27 and #30

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,9 @@ shellcheck *.sh setup-*.sh scripts/*.sh
 # Verify 1Password connectivity (dev machine only — verify hostname first!)
 op vault list      # service account — Automation vault only, non-interactive
 opp vault list     # interactive auth — Personal vault access (prep-airdrop.sh requires this)
+# `opp` is a local shell function from ~/.config/bash/1password.sh (dotfiles)
+# that runs `op` in a subshell with OP_SERVICE_ACCOUNT_TOKEN unset, forcing
+# interactive Personal-vault auth. Not a standard macOS/Homebrew tool.
 ```
 
 <!-- headroom:learn:start -->

--- a/prep-airdrop.sh
+++ b/prep-airdrop.sh
@@ -666,13 +666,13 @@ fi
 # Sourced from the dev machine's login Keychain (created during Phase 1–3 bootstrap).
 # Stored under SERVER_NAME_LOWER account in external keychain; first-boot.sh
 # re-installs it under ADMIN_USERNAME so claude-wrapper's id -un lookup matches.
-echo "Provisioning 1Password service account token..."
 op_service_token="$(security find-generic-password \
   -a "${USER}" \
   -s "op-service-account-claude-automation" \
   -w 2>/dev/null || true)"
 
 if [[ -n "${op_service_token}" ]]; then
+  echo "Provisioning 1Password service account token..."
   store_external_keychain_credential \
     "op-service-account-claude-automation" \
     "${SERVER_NAME_LOWER}" \

--- a/scripts/server/first-boot.sh
+++ b/scripts/server/first-boot.sh
@@ -488,6 +488,11 @@ import_external_keychain_credentials() {
   # timeout so once unlocked (manually or via console login), it stays unlocked
   # until sleep. This is what lets claude-wrapper read OP_SERVICE_ACCOUNT_TOKEN
   # from the Keychain without re-prompting.
+  #
+  # Flags: -l = lock-on-sleep, -u = lock-after-timeout (controlled by -t).
+  # Omitting -t leaves the timeout unset, which `security` interprets as
+  # "no timeout" (confirmed via `security show-keychain-info`). So "-l -u"
+  # without "-t N" = lock-on-sleep only, no idle lock.
   if security set-keychain-settings -l -u "${HOME}/Library/Keychains/login.keychain-db"; then
     show_log "✅ Login keychain configured: lock-on-sleep, no idle timeout"
   else


### PR DESCRIPTION
## Summary

Wraps up the three non-blocking issues filed by the pre-merge analyzer on the recent keychain PRs:

- **#28** — \`prep-airdrop.sh\` printed \`Provisioning...\` before the nil-check, so operators saw a misleading line followed by a warning when the dev Keychain lacked the token. Moved the echo inside the success branch.
- **#29** — \`CLAUDE.md\` referenced \`opp\` without provenance. Added a note that it's a local shell function from \`~/.config/bash/1password.sh\` (dotfiles), not a standard tool.
- **#31** — \`first-boot.sh\` used \`security set-keychain-settings -l -u\` for the no-timeout effect, which is non-obvious per the man page (the no-timeout comes from omitting \`-t\`, not from \`-u\`). Added an explanatory comment.

Closes #28, closes #29, closes #31.

## Test plan

- [x] \`shellcheck -S info\` clean on both shell files
- [x] Local code-reviewer + adversarial-reviewer pass
- [ ] Post-merge: next fresh target provisioning confirms behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)