### PR TITLE
chore: bump claude-blocking-review to @v2

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   claude-review:
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v1
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v2
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:


### PR DESCRIPTION
Bellwether migration to v2 of the reusable Claude review workflow. Picks up the new BLOCK-only gate, doc-only fast-skip, SHA marker on reviews, and prior-comment minimize.

One-line pin change: `@v1` → `@v2`. Inputs, secrets, status check name all unchanged.

Release notes: https://github.com/smartwatermelon/github-workflows/releases/tag/v2.0.0

Expected review behavior on this PR:
- Shorter duration (narrow prompt targets BLOCK criteria only)
- Review comment body starts with a machine-readable SHA marker
- No stale prior comments to minimize on first v2 run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

[skip-claude-review: workflow-validation — this PR modifies the caller workflow file itself; the anthropics/claude-code-action by design refuses to run when the file differs from main. Real v2 review will run on the next PR after this merges.]