### PR TITLE
chore: add msmtp to formulae

### DIFF
--- a/config/formulae.txt
+++ b/config/formulae.txt
@@ -52,3 +52,7 @@ task
 
 # Network tools (retained)
 openssh
+
+# Mail delivery (ralph-burndown nightly failure emails; see
+# smartwatermelon/ralph-burndown scripts/bootstrap-msmtp-keychain.sh)
+msmtp


### PR DESCRIPTION
## Summary

Adds \`msmtp\` to \`config/formulae.txt\` so fresh mimolette builds install it automatically. msmtp is the delivery mechanism for ralph-burndown's nightly failure emails — see the Phase 4 pivot in [smartwatermelon/ralph-burndown#99](https://github.com/smartwatermelon/ralph-burndown/pull/99).

Gmail app password is sourced from a 1Password Automation vault and mirrored into a dedicated never-auto-lock keychain by \`scripts/bootstrap-msmtp-keychain.sh\` (in the ralph-burndown repo, not in this repo). The login keychain would not be usable since it locks outside GUI sessions and the LaunchAgent runs at 02:00.

## Test plan

- [x] Pre-commit + pre-push review clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)