### PR TITLE
refactor(headroom): LaunchAgent → LaunchDaemon for headless

### DIFF
--- a/app-setup/claude-setup.sh
+++ b/app-setup/claude-setup.sh
@@ -307,27 +307,47 @@ main() {
         "${claude_cmd}" mcp add headroom -s user -- "${headroom_bin}" mcp serve >>"${LOG_FILE}" 2>&1 || add_exit=$?
         check_success "${add_exit}" "Add headroom MCP (global)" || true
 
-        # Install headroom proxy LaunchAgent (provides ANTHROPIC_BASE_URL proxy)
+        # Install headroom proxy LaunchDaemon (provides ANTHROPIC_BASE_URL proxy)
+        # Daemon (not Agent) because the target is a headless build server: no
+        # GUI login means user-level LaunchAgents never auto-load on macOS, even
+        # with LimitLoadToSessionType=Background. Daemons fire at boot in the
+        # system domain regardless of session state. UserName/GroupName run the
+        # process as the install user so logs and pipx-managed binaries in the
+        # user's home stay accessible.
         local proxy_port=8787
         if lsof -i ":${proxy_port}" -sTCP:LISTEN &>/dev/null; then
-          show_log "WARNING: port ${proxy_port} already in use — skipping headroom proxy LaunchAgent"
+          show_log "WARNING: port ${proxy_port} already in use — skipping headroom proxy LaunchDaemon"
         else
-          local plist_name="com.headroom.proxy.plist"
-          local plist_dest="${HOME}/Library/LaunchAgents/${plist_name}"
-          # Headless build server: no GUI login on the target, so the agent must
-          # load into the Background session (created on ssh login), not Aqua.
-          local user_domain
-          user_domain="user/$(id -u)"
+          local plist_label="com.headroom.proxy"
+          local plist_dest="/Library/LaunchDaemons/${plist_label}.plist"
+          local plist_tmp
+          plist_tmp="$(mktemp -t headroom-proxy.plist.XXXXXX)"
+          local user_name
+          user_name="$(id -un)"
+          local group_name
+          group_name="$(id -gn)"
           mkdir -p "${HOME}/Library/Logs/headroom"
-          cat >"${plist_dest}" <<PLIST
+
+          # Remove legacy user-level LaunchAgent if a previous run of this
+          # script installed one. Bootout first to release port 8787.
+          local legacy_agent="${HOME}/Library/LaunchAgents/${plist_label}.plist"
+          if [[ -f "${legacy_agent}" ]]; then
+            launchctl bootout "user/$(id -u)/${plist_label}" 2>/dev/null || true
+            rm -f "${legacy_agent}"
+            show_log "Removed legacy headroom LaunchAgent (replaced by LaunchDaemon)"
+          fi
+
+          cat >"${plist_tmp}" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.headroom.proxy</string>
-    <key>LimitLoadToSessionType</key>
-    <string>Background</string>
+    <string>${plist_label}</string>
+    <key>UserName</key>
+    <string>${user_name}</string>
+    <key>GroupName</key>
+    <string>${group_name}</string>
     <key>ProgramArguments</key>
     <array>
         <string>${headroom_bin}</string>
@@ -341,6 +361,8 @@ main() {
     <dict>
         <key>HEADROOM_PROXY_PORT</key>
         <string>${proxy_port}</string>
+        <key>HOME</key>
+        <string>${HOME}</string>
     </dict>
     <key>WorkingDirectory</key>
     <string>${HOME}</string>
@@ -359,9 +381,23 @@ main() {
 </dict>
 </plist>
 PLIST
-          launchctl bootout "${user_domain}/com.headroom.proxy" 2>/dev/null || true
-          launchctl bootstrap "${user_domain}" "${plist_dest}" 2>>"${LOG_FILE}"
-          show_log "OK: headroom proxy LaunchAgent installed and loaded (port ${proxy_port})"
+          if ! plutil -lint "${plist_tmp}" >>"${LOG_FILE}" 2>&1; then
+            collect_error "headroom proxy plist failed plutil -lint"
+            rm -f "${plist_tmp}"
+          else
+            sudo /bin/launchctl bootout "system/${plist_label}" 2>/dev/null || true
+            if ! sudo /usr/bin/install -o root -g wheel -m 0644 "${plist_tmp}" "${plist_dest}" 2>>"${LOG_FILE}"; then
+              collect_error "headroom proxy plist install failed"
+              rm -f "${plist_tmp}"
+            else
+              rm -f "${plist_tmp}"
+              if sudo /bin/launchctl bootstrap system "${plist_dest}" 2>>"${LOG_FILE}"; then
+                show_log "OK: headroom proxy LaunchDaemon installed and loaded (port ${proxy_port})"
+              else
+                collect_error "headroom proxy LaunchDaemon bootstrap failed"
+              fi
+            fi
+          fi
         fi
       else
         collect_error "headroom-ai installation failed (pipx exit ${pipx_exit})"

--- a/app-setup/claude-setup.sh
+++ b/app-setup/claude-setup.sh
@@ -315,10 +315,21 @@ main() {
         # process as the install user so logs and pipx-managed binaries in the
         # user's home stay accessible.
         local proxy_port=8787
+        local plist_label="com.headroom.proxy"
+
+        # Remove legacy user-level LaunchAgent first — runs before the port
+        # check so a stale agent holding :8787 doesn't cause this run to skip
+        # the daemon install. No-op when the legacy plist isn't present.
+        local legacy_agent="${HOME}/Library/LaunchAgents/${plist_label}.plist"
+        if [[ -f "${legacy_agent}" ]]; then
+          launchctl bootout "user/$(id -u)/${plist_label}" 2>/dev/null || true
+          rm -f "${legacy_agent}"
+          show_log "Removed legacy headroom LaunchAgent (replaced by LaunchDaemon)"
+        fi
+
         if lsof -i ":${proxy_port}" -sTCP:LISTEN &>/dev/null; then
           show_log "WARNING: port ${proxy_port} already in use — skipping headroom proxy LaunchDaemon"
         else
-          local plist_label="com.headroom.proxy"
           local plist_dest="/Library/LaunchDaemons/${plist_label}.plist"
           local plist_tmp
           plist_tmp="$(mktemp -t headroom-proxy.plist.XXXXXX)"
@@ -327,15 +338,6 @@ main() {
           local group_name
           group_name="$(id -gn)"
           mkdir -p "${HOME}/Library/Logs/headroom"
-
-          # Remove legacy user-level LaunchAgent if a previous run of this
-          # script installed one. Bootout first to release port 8787.
-          local legacy_agent="${HOME}/Library/LaunchAgents/${plist_label}.plist"
-          if [[ -f "${legacy_agent}" ]]; then
-            launchctl bootout "user/$(id -u)/${plist_label}" 2>/dev/null || true
-            rm -f "${legacy_agent}"
-            show_log "Removed legacy headroom LaunchAgent (replaced by LaunchDaemon)"
-          fi
 
           cat >"${plist_tmp}" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>

--- a/app-setup/claude-setup.sh
+++ b/app-setup/claude-setup.sh
@@ -314,8 +314,10 @@ main() {
         else
           local plist_name="com.headroom.proxy.plist"
           local plist_dest="${HOME}/Library/LaunchAgents/${plist_name}"
-          local gui_domain
-          gui_domain="gui/$(id -u)"
+          # Headless build server: no GUI login on the target, so the agent must
+          # load into the Background session (created on ssh login), not Aqua.
+          local user_domain
+          user_domain="user/$(id -u)"
           mkdir -p "${HOME}/Library/Logs/headroom"
           cat >"${plist_dest}" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -324,6 +326,8 @@ main() {
 <dict>
     <key>Label</key>
     <string>com.headroom.proxy</string>
+    <key>LimitLoadToSessionType</key>
+    <string>Background</string>
     <key>ProgramArguments</key>
     <array>
         <string>${headroom_bin}</string>
@@ -355,8 +359,8 @@ main() {
 </dict>
 </plist>
 PLIST
-          launchctl bootout "${gui_domain}/com.headroom.proxy" 2>/dev/null || true
-          launchctl bootstrap "${gui_domain}" "${plist_dest}" 2>>"${LOG_FILE}"
+          launchctl bootout "${user_domain}/com.headroom.proxy" 2>/dev/null || true
+          launchctl bootstrap "${user_domain}" "${plist_dest}" 2>>"${LOG_FILE}"
           show_log "OK: headroom proxy LaunchAgent installed and loaded (port ${proxy_port})"
         fi
       else


### PR DESCRIPTION
## Summary
- Replace `~/Library/LaunchAgents/com.headroom.proxy.plist` (user-level LaunchAgent) with `/Library/LaunchDaemons/com.headroom.proxy.plist` (system-level daemon).
- Rationale: macOS launchd does not auto-bootstrap user LaunchAgents into the Background session created on ssh login — auto-bootstrap is tied to the Aqua/loginwindow session. On a headless build server (no GUI login) this means user-level agents never fire, even with `LimitLoadToSessionType=Background`. Verified empirically on MIMOLETTE: post-reboot, `user/501` contained zero user-defined services.
- Daemon runs as the install user via `UserName`/`GroupName` so logs and pipx-managed binaries in `$HOME` stay accessible. `KeepAlive` + `ThrottleInterval=10` tolerate the boot-time race against external-SSD automount: if the daemon races ahead of the volume mount, it crash-loops at 10s intervals until the binary is reachable.
- Cleans up legacy user-level LaunchAgent (bootout + `rm`) on upgrade. Cleanup hoisted above the `lsof :8787` port check so a stale agent holding the port doesn't cause the install to be skipped.

## Test plan
- [x] `plutil -lint` passes on rendered plist (scripted check before install)
- [x] Shellcheck clean in edited region
- [x] Pre-commit `code-reviewer` + `adversarial-reviewer` PASS on all 3 commits
- [x] Pre-push Semgrep + full-diff + codebase review all PASS
- [x] Manual deploy on MIMOLETTE: daemon bootstraps, `/livez` + `/readyz` return healthy
- [x] Post-reboot verification on MIMOLETTE (headless, no GUI login): daemon auto-loads at boot (pid 592, uptime 133s at first ssh), port 8787 listening, `/livez` healthy
- [x] Regression check: external-storage automount unchanged — still fires at boot with `runs=1, exit=0, MOUNTED`

## Context
Surfaced while validating external-storage automount on a fresh-boot headless Mac mini. The automount LaunchDaemon fires correctly at boot; the same machine's LaunchAgents did not. Related issue filed for `ralph-nightly` in `smartwatermelon/ralph-burndown#109` (out of scope for this repo). LaunchAgent variants of Headroom remain appropriate for interactive Macs (laptops with daily desktop login) and are installed elsewhere, not by this repo.

## Commit evolution
- `7a7affd` — first attempt: add `LimitLoadToSessionType=Background` to the LaunchAgent. Didn't work — launchd doesn't auto-bootstrap user agents into Background sessions.
- `2cfe33e` — pivot to LaunchDaemon (system domain, root-installed, runs as user). This is the working approach.
- `64b77e1` — code-reviewer fix: hoist legacy-agent cleanup above the port-in-use check so a stale agent holding :8787 doesn't cause the install to be skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)