### PR TITLE
fix(ci): remove issues trigger + downgrade blocking review to Haiku

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -15,5 +15,6 @@ jobs:
     uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3.0.0
     with:
       pr_number: ${{ github.event.pull_request.number }}
+      model: "claude-haiku-4-5-20251001"
     secrets:
       claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,8 +11,6 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
 
@@ -21,8 +19,7 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association))
     uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v3
     secrets:
       claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove `issues` event trigger from claude.yml to prevent cascade invocations
- Downgrade CI blocking review model to Haiku (docs/config/scripts repo — Sonnet is overkill)

## Test plan
- [ ] Verify workflow no longer triggers on issue creation events
- [ ] Verify @claude mentions in comments still trigger the workflow
- [ ] Verify blocking review runs with Haiku model on next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)