### PR TITLE
fix: headroom plist teardown error + 3 low-risk items from #38

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -129,7 +129,7 @@ NAS_*                              # No NAS mounting
 
 ```bash
 DOTFILES_REPO="git@github.com:smartwatermelon/dotfiles.git"
-ANDROID_SDK_VERSION="34"           # Target Android SDK
+ANDROID_SDK_VERSION="36"           # Target Android SDK
 NODE_VERSION="lts"                 # Node.js version (or "20", "22", etc.)
 XCODE_VERSION=""                   # Empty = latest from App Store
 ```

--- a/app-setup/android-setup.sh
+++ b/app-setup/android-setup.sh
@@ -56,7 +56,7 @@ HOSTNAME="${HOSTNAME_OVERRIDE:-${SERVER_NAME}}"
 HOSTNAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<<"${HOSTNAME}")"
 
 # SDK version from config with default
-SDK_VERSION="${ANDROID_SDK_VERSION:-34}"
+SDK_VERSION="${ANDROID_SDK_VERSION:-36}"
 
 # Logging configuration
 LOG_DIR="${HOME}/.local/state"

--- a/app-setup/claude-setup.sh
+++ b/app-setup/claude-setup.sh
@@ -115,7 +115,7 @@ remove_headroom() {
     if sudo rm -f "/Library/LaunchDaemons/${plist_label}.plist" 2>>"${LOG_FILE}"; then
       show_log "Removed headroom proxy LaunchDaemon plist"
     else
-      show_log "WARNING: failed to remove /Library/LaunchDaemons/${plist_label}.plist (sudo required)"
+      collect_error "failed to remove /Library/LaunchDaemons/${plist_label}.plist (sudo required); plist will persist and headroom may respawn on next boot — subsequent runs will retry"
     fi
   fi
 

--- a/app-setup/node-setup.sh
+++ b/app-setup/node-setup.sh
@@ -99,6 +99,11 @@ check_success() {
 }
 
 # Global npm packages to install
+# NOTE: "n" (Node version manager) is intentionally included to match the
+# asiago reference build server (see issue #38, item 2). It's used by
+# downstream project preflight scripts to switch Node versions; on a box
+# where Node itself is Homebrew-managed, `n` is expected to remain unused
+# for that purpose to avoid it silently taking over /usr/local/bin/node.
 readonly -a GLOBAL_PACKAGES=(
   "eas-cli"
   "npm-check-updates"
@@ -229,7 +234,9 @@ main() {
     esac
 
     if [[ "${pkg}" == "puppeteer" ]]; then
-      if node -e "require('puppeteer')" &>/dev/null; then
+      # Global installs aren't on node's default require() path; point
+      # NODE_PATH at the global npm lib dir so require() can find it.
+      if NODE_PATH="${NPM_GLOBAL_DIR}/lib/node_modules" node -e "require('puppeteer')" &>/dev/null; then
         show_log "OK: ${pkg} (installed)"
       else
         collect_error "${pkg} module not found after installation"

--- a/app-setup/node-setup.sh
+++ b/app-setup/node-setup.sh
@@ -218,7 +218,8 @@ main() {
   for pkg in "${GLOBAL_PACKAGES[@]}"; do
     # Get the command name (first part before any @version)
     local cmd="${pkg%%@*}"
-    # Map package name to installed command name where they differ
+    # Map package name to installed command name where they differ.
+    # puppeteer is a library with no CLI binary; verify via node -e instead.
     case "${cmd}" in
       eas-cli) cmd="eas" ;;
       npm-check-updates) cmd="ncu" ;;
@@ -227,7 +228,13 @@ main() {
       *) ;;
     esac
 
-    if command -v "${cmd}" &>/dev/null; then
+    if [[ "${pkg}" == "puppeteer" ]]; then
+      if node -e "require('puppeteer')" &>/dev/null; then
+        show_log "OK: ${pkg} (installed)"
+      else
+        collect_error "${pkg} module not found after installation"
+      fi
+    elif command -v "${cmd}" &>/dev/null; then
       local pkg_version
       pkg_version="$("${cmd}" --version 2>/dev/null || echo "installed")"
       show_log "OK: ${pkg} (${pkg_version})"

--- a/app-setup/node-setup.sh
+++ b/app-setup/node-setup.sh
@@ -102,6 +102,10 @@ check_success() {
 readonly -a GLOBAL_PACKAGES=(
   "eas-cli"
   "npm-check-updates"
+  "n"
+  "netlify-cli"
+  "puppeteer"
+  "url-decode-encode-cli"
 )
 
 # npm global directory
@@ -214,10 +218,12 @@ main() {
   for pkg in "${GLOBAL_PACKAGES[@]}"; do
     # Get the command name (first part before any @version)
     local cmd="${pkg%%@*}"
-    # eas-cli installs as 'eas', npm-check-updates installs as 'ncu'
+    # Map package name to installed command name where they differ
     case "${cmd}" in
       eas-cli) cmd="eas" ;;
       npm-check-updates) cmd="ncu" ;;
+      netlify-cli) cmd="netlify" ;;
+      url-decode-encode-cli) cmd="url-encode" ;;
       *) ;;
     esac
 
@@ -229,6 +235,23 @@ main() {
       collect_error "${pkg} command '${cmd}' not found after installation"
     fi
   done
+
+  # eas login hint — informational only, must not fail setup
+  section "Checking EAS Login Status"
+  if command -v eas &>/dev/null; then
+    local eas_whoami_output
+    eas_whoami_output="$(eas whoami 2>&1 || true)"
+    if [[ "${eas_whoami_output}" == *"Not logged in"* ]]; then
+      show_log ""
+      show_log "NOTE: EAS is not logged in. Post-setup checklist:"
+      show_log "  - Run 'eas login' to authenticate with your Expo account"
+      show_log ""
+    else
+      show_log "EAS login: ${eas_whoami_output}"
+    fi
+  else
+    log "eas command not available; skipping EAS login check"
+  fi
 
   if [[ ${#COLLECTED_ERRORS[@]} -gt 0 ]]; then
     show_log ""

--- a/config/config.conf.template
+++ b/config/config.conf.template
@@ -16,7 +16,7 @@ MONITORING_EMAIL="your-email@example.com"
 
 # Development configuration
 DOTFILES_REPO="git@github.com:YOUR_USER/dotfiles.git"
-ANDROID_SDK_VERSION="34"
+ANDROID_SDK_VERSION="36"
 NODE_VERSION="lts"
 XCODE_VERSION=""  # Empty = latest from App Store
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ SSH_KEY_ITEM="SSH Keys"
 
 # Development configuration
 DOTFILES_REPO="git@github.com:smartwatermelon/dotfiles.git"
-ANDROID_SDK_VERSION="34"
+ANDROID_SDK_VERSION="36"
 NODE_VERSION="lts"
 XCODE_VERSION=""
 
@@ -76,7 +76,7 @@ The system uses 1Password for initial credential retrieval during setup preparat
 
 **ANDROID_SDK_VERSION**: Android SDK platform version to install
 
-- **Default**: "34"
+- **Default**: "36"
 - **Usage**: Installed via Android command-line tools
 - **Example**: `ANDROID_SDK_VERSION="35"`
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -43,7 +43,7 @@ SSH_KEY_ITEM="SSH Keys"
 DOTFILES_REPO="git@github.com:smartwatermelon/dotfiles.git"
 
 # Android SDK platform version to install
-ANDROID_SDK_VERSION="34"
+ANDROID_SDK_VERSION="36"
 
 # Node.js version to install via nvm
 NODE_VERSION="lts"
@@ -219,7 +219,7 @@ These have sensible defaults if not set:
 
 - `HOSTNAME_OVERRIDE` (defaults to `SERVER_NAME`)
 - `DOTFILES_REPO` (dotfiles clone skipped if empty)
-- `ANDROID_SDK_VERSION` (defaults to "34")
+- `ANDROID_SDK_VERSION` (defaults to "36")
 - `NODE_VERSION` (defaults to "lts")
 - `XCODE_VERSION` (empty = latest from App Store)
 - `SSH_KEY_ITEM` (defaults to "SSH Keys")

--- a/prep-airdrop.sh
+++ b/prep-airdrop.sh
@@ -113,7 +113,7 @@ if [[ ! -f "${CONFIG_FILE}" ]]; then
     printf 'MONITORING_EMAIL=%q\n\n' "${MONITORING_EMAIL}"
     printf '# Development configuration\n'
     printf 'DOTFILES_REPO=%q\n' "${DOTFILES_REPO}"
-    printf 'ANDROID_SDK_VERSION=%q\n' "${ANDROID_SDK_VERSION:-34}"
+    printf 'ANDROID_SDK_VERSION=%q\n' "${ANDROID_SDK_VERSION:-36}"
     printf 'NODE_VERSION=%q\n' "${NODE_VERSION:-lts}"
     printf 'XCODE_VERSION=%q\n\n' "${XCODE_VERSION:-}"
     printf '# Terminal configuration (optional)\n'


### PR DESCRIPTION
## Issue #57 — sudo rm failure surfaced

`remove_headroom()` in `app-setup/claude-setup.sh` logged a WARNING and continued silently when `sudo rm -f` on the LaunchDaemon plist failed, so the failure never counted toward the script's error total or exit code. Promoted it to `collect_error()`, matching the file's existing error-collection convention (see `check_success()` / the final `COLLECTED_ERRORS` check). Teardown remains idempotent — a leftover plist will be retried and removed on the next run.

Fixes #57

## Issue #38 — 3 cherry-picked items (partial, not the full epic)

Issue #38 is a 10-item tracking epic for MIMOLETTE/asiago provisioning parity. Per explicit scope decision, only these 3 low-risk items are addressed here; everything else is deferred to a dedicated follow-up session:

- **Item 9 (eas login hint)**: `app-setup/node-setup.sh` now runs `eas whoami` after eas-cli install and prints a post-setup checklist hint to run `eas login` if not authenticated. Purely informational — never fails the script.
- **Item 5 (SDK_VERSION bump)**: `app-setup/android-setup.sh` default bumped 34 → 36 (env-var override `ANDROID_SDK_VERSION` still respected). Also updated the 5 doc/template locations that hardcoded the old default (`config/config.conf.template`, `docs/configuration.md`, `docs/environment-variables.md`, `SPEC.md`, `prep-airdrop.sh`) so operators following the docs don't silently undo the bump.
- **Item 2 (expand npm globals, additive only)**: `GLOBAL_PACKAGES` in `node-setup.sh` gains `n`, `netlify-cli`, `puppeteer`, `url-decode-encode-cli` to match asiago's actual global installs. Did **not** add `andrewrich`/`dependencies` — issue #38 explicitly identifies those as install detritus, not real packages. Verification command-name mapping extended accordingly (`netlify-cli` → `netlify`, `url-decode-encode-cli` → `url-encode`); `puppeteer` has no CLI binary so it's verified via `node -e "require('puppeteer')"` with `NODE_PATH` pointed at the global npm lib dir (verified locally that a bare `require()` fails without this, since global installs aren't on node's default require path).

**Explicitly NOT touched** (remain open on #38 for a dedicated follow-up session):
- Item 1: npm prefix / `NPM_GLOBAL_DIR` / PATH handling
- Item 3: Android system-image install
- Item 4: AVD creation
- Item 6: cmdline-tools → `~/Library/Android/sdk` symlink
- Item 7: `.profile` audit step
- Item 8: credential handoff docs/automation
- Item 10: semgrep settings `api_token` injection

Addresses #38 (partial — see scope breakdown above; most of the epic remains open)

## Review notes

Pre-push whole-codebase review caught and this PR fixes two real bugs it found in its own earlier commits (not pre-existing code): a `puppeteer` verification check that would always spuriously fail (wrong `command -v` and later a NODE_PATH gap), and SDK-version doc drift. Both are fixed in follow-up commits on this branch. Three additional non-blocking observations were auto-filed as tracking issues (#61, #62, #63) — #61 (`build-tools;36.0.0` availability) was manually verified as a non-issue (`sdkmanager --list` confirms it exists in the stable channel); #62 and #63 are legitimate but low-priority polish items left for later.

## Testing

- `shellcheck -S info` clean on all four modified shell scripts (`claude-setup.sh`, `node-setup.sh`, `android-setup.sh`, `prep-airdrop.sh`) — no disable directives used.
- `bash -n` syntax check clean on all modified scripts.
- No BATS or other test suite exists in this repo to run.
- Manually verified the puppeteer `NODE_PATH` fix against a real `npm install -g puppeteer --prefix <tmpdir>` + `require()` round trip.
- Manually verified `build-tools;36.0.0` is available via `sdkmanager --list`.